### PR TITLE
feat: ユーザー一括作成・IdP紐付け・Graph API表示への全面移行

### DIFF
--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -115,7 +115,7 @@ func main() {
 	roleCache := authz.NewRoleCache(env.Get().Auth.RoleCacheTTL)
 
 	// service
-	userService := service.NewUser(db, userRepository)
+	userService := service.NewUser(db, userRepository, groupRepository)
 	authService := service.NewAuthService(db, userRepository, roleCache, authorizerInstance)
 	groupService := service.NewGroup(db, groupRepository, userRepository)
 	teamService := service.NewTeam(db, teamRepository, userRepository)

--- a/api/graph/generated.go
+++ b/api/graph/generated.go
@@ -8,11 +8,10 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"sports-day/api/graph/model"
 	"strconv"
 	"sync"
 	"sync/atomic"
-
-	"sports-day/api/graph/model"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
@@ -66,6 +65,10 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	BatchCreateUsersResult struct {
+		Users func(childComplexity int) int
+	}
+
 	Competition struct {
 		BreakDuration   func(childComplexity int) int
 		DefaultLocation func(childComplexity int) int
@@ -164,6 +167,7 @@ type ComplexityRoot struct {
 		AddSportScenes                 func(childComplexity int, id string, input model.AddSportScenesInput) int
 		ApplyCompetitionDefaults       func(childComplexity int, id string, input model.ApplyCompetitionDefaultsInput) int
 		AssignSeedTeam                 func(childComplexity int, input model.AssignSeedTeamInput) int
+		BatchCreateUsers               func(childComplexity int, input model.BatchCreateUsersInput) int
 		CreateCompetition              func(childComplexity int, input model.CreateCompetitionInput) int
 		CreateGroup                    func(childComplexity int, input model.CreateGroupInput) int
 		CreateImageUploadURL           func(childComplexity int, input model.CreateImageUploadURLInput) int
@@ -236,7 +240,6 @@ type ComplexityRoot struct {
 		UpdateTeam                     func(childComplexity int, id string, input model.UpdateTeamInput) int
 		UpdateTeamUsers                func(childComplexity int, id string, input model.UpdateTeamUsersInput) int
 		UpdateTournament               func(childComplexity int, id string, input model.UpdateTournamentInput) int
-		UpdateUser                     func(childComplexity int, id string, input model.UpdateUserInput) int
 		UpdateUserRole                 func(childComplexity int, userID string, role model.Role) int
 	}
 
@@ -400,12 +403,10 @@ type ComplexityRoot struct {
 	}
 
 	User struct {
-		Email     func(childComplexity int) int
 		Groups    func(childComplexity int) int
 		ID        func(childComplexity int) int
 		Identify  func(childComplexity int) int
 		Judgments func(childComplexity int) int
-		Name      func(childComplexity int) int
 		Role      func(childComplexity int) int
 		Teams     func(childComplexity int) int
 	}
@@ -451,7 +452,7 @@ type MatchResolver interface {
 }
 type MutationResolver interface {
 	CreateUser(ctx context.Context, input model.CreateUserInput) (*model.User, error)
-	UpdateUser(ctx context.Context, id string, input model.UpdateUserInput) (*model.User, error)
+	BatchCreateUsers(ctx context.Context, input model.BatchCreateUsersInput) (*model.BatchCreateUsersResult, error)
 	DeleteUser(ctx context.Context, id string) (*model.User, error)
 	CreateGroup(ctx context.Context, input model.CreateGroupInput) (*model.Group, error)
 	DeleteGroup(ctx context.Context, id string) (*model.Group, error)
@@ -642,6 +643,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	ec := executionContext{nil, e, 0, 0, nil}
 	_ = ec
 	switch typeName + "." + field {
+
+	case "BatchCreateUsersResult.users":
+		if e.complexity.BatchCreateUsersResult.Users == nil {
+			break
+		}
+
+		return e.complexity.BatchCreateUsersResult.Users(childComplexity), true
 
 	case "Competition.breakDuration":
 		if e.complexity.Competition.BreakDuration == nil {
@@ -1151,6 +1159,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.AssignSeedTeam(childComplexity, args["input"].(model.AssignSeedTeamInput)), true
+
+	case "Mutation.batchCreateUsers":
+		if e.complexity.Mutation.BatchCreateUsers == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_batchCreateUsers_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.BatchCreateUsers(childComplexity, args["input"].(model.BatchCreateUsersInput)), true
 
 	case "Mutation.createCompetition":
 		if e.complexity.Mutation.CreateCompetition == nil {
@@ -2015,18 +2035,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.UpdateTournament(childComplexity, args["id"].(string), args["input"].(model.UpdateTournamentInput)), true
-
-	case "Mutation.updateUser":
-		if e.complexity.Mutation.UpdateUser == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_updateUser_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.UpdateUser(childComplexity, args["id"].(string), args["input"].(model.UpdateUserInput)), true
 
 	case "Mutation.updateUserRole":
 		if e.complexity.Mutation.UpdateUserRole == nil {
@@ -2922,13 +2930,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TournamentSlot.Tournament(childComplexity), true
 
-	case "User.email":
-		if e.complexity.User.Email == nil {
-			break
-		}
-
-		return e.complexity.User.Email(childComplexity), true
-
 	case "User.groups":
 		if e.complexity.User.Groups == nil {
 			break
@@ -2956,13 +2957,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.User.Judgments(childComplexity), true
-
-	case "User.name":
-		if e.complexity.User.Name == nil {
-			break
-		}
-
-		return e.complexity.User.Name(childComplexity), true
 
 	case "User.role":
 		if e.complexity.User.Role == nil {
@@ -3004,6 +2998,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputAddSportScenesInput,
 		ec.unmarshalInputApplyCompetitionDefaultsInput,
 		ec.unmarshalInputAssignSeedTeamInput,
+		ec.unmarshalInputBatchCreateUsersInput,
 		ec.unmarshalInputCreateCompetitionInput,
 		ec.unmarshalInputCreateGroupInput,
 		ec.unmarshalInputCreateImageUploadURLInput,
@@ -3054,7 +3049,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateTeamInput,
 		ec.unmarshalInputUpdateTeamUsersInput,
 		ec.unmarshalInputUpdateTournamentInput,
-		ec.unmarshalInputUpdateUserInput,
 	)
 	first := true
 
@@ -3507,6 +3501,29 @@ func (ec *executionContext) field_Mutation_assignSeedTeam_argsInput(
 	}
 
 	var zeroVal model.AssignSeedTeamInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_batchCreateUsers_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_batchCreateUsers_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_batchCreateUsers_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.BatchCreateUsersInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNBatchCreateUsersInput2sportsᚑdayᚋapiᚋgraphᚋmodelᚐBatchCreateUsersInput(ctx, tmp)
+	}
+
+	var zeroVal model.BatchCreateUsersInput
 	return zeroVal, nil
 }
 
@@ -5675,47 +5692,6 @@ func (ec *executionContext) field_Mutation_updateUserRole_argsRole(
 	return zeroVal, nil
 }
 
-func (ec *executionContext) field_Mutation_updateUser_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := ec.field_Mutation_updateUser_argsID(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["id"] = arg0
-	arg1, err := ec.field_Mutation_updateUser_argsInput(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg1
-	return args, nil
-}
-func (ec *executionContext) field_Mutation_updateUser_argsID(
-	ctx context.Context,
-	rawArgs map[string]any,
-) (string, error) {
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
-	if tmp, ok := rawArgs["id"]; ok {
-		return ec.unmarshalNID2string(ctx, tmp)
-	}
-
-	var zeroVal string
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Mutation_updateUser_argsInput(
-	ctx context.Context,
-	rawArgs map[string]any,
-) (model.UpdateUserInput, error) {
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-	if tmp, ok := rawArgs["input"]; ok {
-		return ec.unmarshalNUpdateUserInput2sportsᚑdayᚋapiᚋgraphᚋmodelᚐUpdateUserInput(ctx, tmp)
-	}
-
-	var zeroVal model.UpdateUserInput
-	return zeroVal, nil
-}
-
 func (ec *executionContext) field_Query_Information_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -6321,6 +6297,64 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 // endregion ************************** directives.gotpl **************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _BatchCreateUsersResult_users(ctx context.Context, field graphql.CollectedField, obj *model.BatchCreateUsersResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BatchCreateUsersResult_users(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Users, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.User)
+	fc.Result = res
+	return ec.marshalNUser2ᚕᚖsportsᚑdayᚋapiᚋgraphᚋmodelᚐUserᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BatchCreateUsersResult_users(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BatchCreateUsersResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_User_id(ctx, field)
+			case "identify":
+				return ec.fieldContext_User_identify(ctx, field)
+			case "role":
+				return ec.fieldContext_User_role(ctx, field)
+			case "groups":
+				return ec.fieldContext_User_groups(ctx, field)
+			case "teams":
+				return ec.fieldContext_User_teams(ctx, field)
+			case "judgments":
+				return ec.fieldContext_User_judgments(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+		},
+	}
+	return fc, nil
+}
 
 func (ec *executionContext) _Competition_id(ctx context.Context, field graphql.CollectedField, obj *model.Competition) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Competition_id(ctx, field)
@@ -7230,10 +7264,6 @@ func (ec *executionContext) fieldContext_Group_users(_ context.Context, field gr
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_User_id(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
 			case "identify":
 				return ec.fieldContext_User_identify(ctx, field)
 			case "role":
@@ -7913,10 +7943,6 @@ func (ec *executionContext) fieldContext_Judgment_user(_ context.Context, field 
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_User_id(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
 			case "identify":
 				return ec.fieldContext_User_identify(ctx, field)
 			case "role":
@@ -9296,10 +9322,6 @@ func (ec *executionContext) fieldContext_Mutation_createUser(ctx context.Context
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_User_id(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
 			case "identify":
 				return ec.fieldContext_User_identify(ctx, field)
 			case "role":
@@ -9328,8 +9350,8 @@ func (ec *executionContext) fieldContext_Mutation_createUser(ctx context.Context
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_updateUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_updateUser(ctx, field)
+func (ec *executionContext) _Mutation_batchCreateUsers(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_batchCreateUsers(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -9343,17 +9365,17 @@ func (ec *executionContext) _Mutation_updateUser(ctx context.Context, field grap
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		directive0 := func(rctx context.Context) (any, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().UpdateUser(rctx, fc.Args["id"].(string), fc.Args["input"].(model.UpdateUserInput))
+			return ec.resolvers.Mutation().BatchCreateUsers(rctx, fc.Args["input"].(model.BatchCreateUsersInput))
 		}
 
 		directive1 := func(ctx context.Context) (any, error) {
 			permission, err := ec.unmarshalNString2string(ctx, "user:write")
 			if err != nil {
-				var zeroVal *model.User
+				var zeroVal *model.BatchCreateUsersResult
 				return zeroVal, err
 			}
 			if ec.directives.HasPermission == nil {
-				var zeroVal *model.User
+				var zeroVal *model.BatchCreateUsersResult
 				return zeroVal, errors.New("directive hasPermission is not implemented")
 			}
 			return ec.directives.HasPermission(ctx, nil, directive0, permission)
@@ -9366,10 +9388,10 @@ func (ec *executionContext) _Mutation_updateUser(ctx context.Context, field grap
 		if tmp == nil {
 			return nil, nil
 		}
-		if data, ok := tmp.(*model.User); ok {
+		if data, ok := tmp.(*model.BatchCreateUsersResult); ok {
 			return data, nil
 		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be *sports-day/api/graph/model.User`, tmp)
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *sports-day/api/graph/model.BatchCreateUsersResult`, tmp)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -9381,12 +9403,12 @@ func (ec *executionContext) _Mutation_updateUser(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.User)
+	res := resTmp.(*model.BatchCreateUsersResult)
 	fc.Result = res
-	return ec.marshalNUser2ᚖsportsᚑdayᚋapiᚋgraphᚋmodelᚐUser(ctx, field.Selections, res)
+	return ec.marshalNBatchCreateUsersResult2ᚖsportsᚑdayᚋapiᚋgraphᚋmodelᚐBatchCreateUsersResult(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Mutation_updateUser(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Mutation_batchCreateUsers(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -9394,24 +9416,10 @@ func (ec *executionContext) fieldContext_Mutation_updateUser(ctx context.Context
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "id":
-				return ec.fieldContext_User_id(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
-			case "identify":
-				return ec.fieldContext_User_identify(ctx, field)
-			case "role":
-				return ec.fieldContext_User_role(ctx, field)
-			case "groups":
-				return ec.fieldContext_User_groups(ctx, field)
-			case "teams":
-				return ec.fieldContext_User_teams(ctx, field)
-			case "judgments":
-				return ec.fieldContext_User_judgments(ctx, field)
+			case "users":
+				return ec.fieldContext_BatchCreateUsersResult_users(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type BatchCreateUsersResult", field.Name)
 		},
 	}
 	defer func() {
@@ -9421,7 +9429,7 @@ func (ec *executionContext) fieldContext_Mutation_updateUser(ctx context.Context
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_updateUser_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Mutation_batchCreateUsers_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -9496,10 +9504,6 @@ func (ec *executionContext) fieldContext_Mutation_deleteUser(ctx context.Context
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_User_id(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
 			case "identify":
 				return ec.fieldContext_User_identify(ctx, field)
 			case "role":
@@ -16397,10 +16401,6 @@ func (ec *executionContext) fieldContext_Mutation_updateUserRole(ctx context.Con
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_User_id(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
 			case "identify":
 				return ec.fieldContext_User_identify(ctx, field)
 			case "role":
@@ -17541,10 +17541,6 @@ func (ec *executionContext) fieldContext_Query_users(_ context.Context, field gr
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_User_id(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
 			case "identify":
 				return ec.fieldContext_User_identify(ctx, field)
 			case "role":
@@ -17603,10 +17599,6 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_User_id(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
 			case "identify":
 				return ec.fieldContext_User_identify(ctx, field)
 			case "role":
@@ -17676,10 +17668,6 @@ func (ec *executionContext) fieldContext_Query_me(_ context.Context, field graph
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_User_id(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
 			case "identify":
 				return ec.fieldContext_User_identify(ctx, field)
 			case "role":
@@ -21962,10 +21950,6 @@ func (ec *executionContext) fieldContext_Team_users(_ context.Context, field gra
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_User_id(ctx, field)
-			case "name":
-				return ec.fieldContext_User_name(ctx, field)
-			case "email":
-				return ec.fieldContext_User_email(ctx, field)
 			case "identify":
 				return ec.fieldContext_User_identify(ctx, field)
 			case "role":
@@ -23352,94 +23336,6 @@ func (ec *executionContext) fieldContext_User_id(_ context.Context, field graphq
 	return fc, nil
 }
 
-func (ec *executionContext) _User_name(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_User_name(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Name, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_User_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "User",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _User_email(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_User_email(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Email, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_User_email(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "User",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _User_identify(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_User_identify(ctx, field)
 	if err != nil {
@@ -23731,14 +23627,11 @@ func (ec *executionContext) _UserIdentify_sub(ctx context.Context, field graphql
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNID2string(ctx, field.Selections, res)
+	return ec.marshalOID2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserIdentify_sub(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -25882,6 +25775,33 @@ func (ec *executionContext) unmarshalInputAssignSeedTeamInput(ctx context.Contex
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputBatchCreateUsersInput(ctx context.Context, obj any) (model.BatchCreateUsersInput, error) {
+	var it model.BatchCreateUsersInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"users"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "users":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("users"))
+			data, err := ec.unmarshalNCreateUserInput2ᚕᚖsportsᚑdayᚋapiᚋgraphᚋmodelᚐCreateUserInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Users = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateCompetitionInput(ctx context.Context, obj any) (model.CreateCompetitionInput, error) {
 	var it model.CreateCompetitionInput
 	asMap := map[string]any{}
@@ -26490,27 +26410,27 @@ func (ec *executionContext) unmarshalInputCreateUserInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "email"}
+	fieldsInOrder := [...]string{"microsoftUserId", "groupId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "name":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+		case "microsoftUserId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("microsoftUserId"))
 			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Name = data
-		case "email":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			it.MicrosoftUserID = data
+		case "groupId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("groupId"))
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Email = data
+			it.GroupID = data
 		}
 	}
 
@@ -27729,40 +27649,6 @@ func (ec *executionContext) unmarshalInputUpdateTournamentInput(ctx context.Cont
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputUpdateUserInput(ctx context.Context, obj any) (model.UpdateUserInput, error) {
-	var it model.UpdateUserInput
-	asMap := map[string]any{}
-	for k, v := range obj.(map[string]any) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"name", "email"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "name":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Name = data
-		case "email":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Email = data
-		}
-	}
-
-	return it, nil
-}
-
 // endregion **************************** input.gotpl *****************************
 
 // region    ************************** interface.gotpl ***************************
@@ -27770,6 +27656,45 @@ func (ec *executionContext) unmarshalInputUpdateUserInput(ctx context.Context, o
 // endregion ************************** interface.gotpl ***************************
 
 // region    **************************** object.gotpl ****************************
+
+var batchCreateUsersResultImplementors = []string{"BatchCreateUsersResult"}
+
+func (ec *executionContext) _BatchCreateUsersResult(ctx context.Context, sel ast.SelectionSet, obj *model.BatchCreateUsersResult) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, batchCreateUsersResultImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("BatchCreateUsersResult")
+		case "users":
+			out.Values[i] = ec._BatchCreateUsersResult_users(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
 
 var competitionImplementors = []string{"Competition"}
 
@@ -29010,9 +28935,9 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "updateUser":
+		case "batchCreateUsers":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_updateUser(ctx, field)
+				return ec._Mutation_batchCreateUsers(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -32029,16 +31954,6 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "name":
-			out.Values[i] = ec._User_name(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
-		case "email":
-			out.Values[i] = ec._User_email(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "identify":
 			field := field
 
@@ -32255,9 +32170,6 @@ func (ec *executionContext) _UserIdentify(ctx context.Context, sel ast.Selection
 			out.Values[i] = graphql.MarshalString("UserIdentify")
 		case "sub":
 			out.Values[i] = ec._UserIdentify_sub(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		case "microsoftUserId":
 			out.Values[i] = ec._UserIdentify_microsoftUserId(ctx, field, obj)
 		default:
@@ -32638,6 +32550,25 @@ func (ec *executionContext) unmarshalNAssignSeedTeamInput2sportsᚑdayᚋapiᚋg
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNBatchCreateUsersInput2sportsᚑdayᚋapiᚋgraphᚋmodelᚐBatchCreateUsersInput(ctx context.Context, v any) (model.BatchCreateUsersInput, error) {
+	res, err := ec.unmarshalInputBatchCreateUsersInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNBatchCreateUsersResult2sportsᚑdayᚋapiᚋgraphᚋmodelᚐBatchCreateUsersResult(ctx context.Context, sel ast.SelectionSet, v model.BatchCreateUsersResult) graphql.Marshaler {
+	return ec._BatchCreateUsersResult(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNBatchCreateUsersResult2ᚖsportsᚑdayᚋapiᚋgraphᚋmodelᚐBatchCreateUsersResult(ctx context.Context, sel ast.SelectionSet, v *model.BatchCreateUsersResult) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._BatchCreateUsersResult(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v any) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -32819,6 +32750,28 @@ func (ec *executionContext) unmarshalNCreateTournamentMatchInput2sportsᚑdayᚋ
 func (ec *executionContext) unmarshalNCreateUserInput2sportsᚑdayᚋapiᚋgraphᚋmodelᚐCreateUserInput(ctx context.Context, v any) (model.CreateUserInput, error) {
 	res, err := ec.unmarshalInputCreateUserInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNCreateUserInput2ᚕᚖsportsᚑdayᚋapiᚋgraphᚋmodelᚐCreateUserInputᚄ(ctx context.Context, v any) ([]*model.CreateUserInput, error) {
+	var vSlice []any
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.CreateUserInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNCreateUserInput2ᚖsportsᚑdayᚋapiᚋgraphᚋmodelᚐCreateUserInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNCreateUserInput2ᚖsportsᚑdayᚋapiᚋgraphᚋmodelᚐCreateUserInput(ctx context.Context, v any) (*model.CreateUserInput, error) {
+	res, err := ec.unmarshalInputCreateUserInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNDeleteSportEntriesInput2sportsᚑdayᚋapiᚋgraphᚋmodelᚐDeleteSportEntriesInput(ctx context.Context, v any) (model.DeleteSportEntriesInput, error) {
@@ -34522,11 +34475,6 @@ func (ec *executionContext) unmarshalNUpdateTeamUsersInput2sportsᚑdayᚋapiᚋ
 
 func (ec *executionContext) unmarshalNUpdateTournamentInput2sportsᚑdayᚋapiᚋgraphᚋmodelᚐUpdateTournamentInput(ctx context.Context, v any) (model.UpdateTournamentInput, error) {
 	res, err := ec.unmarshalInputUpdateTournamentInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) unmarshalNUpdateUserInput2sportsᚑdayᚋapiᚋgraphᚋmodelᚐUpdateUserInput(ctx context.Context, v any) (model.UpdateUserInput, error) {
-	res, err := ec.unmarshalInputUpdateUserInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/api/graph/model.graphqls
+++ b/api/graph/model.graphqls
@@ -5,14 +5,12 @@ enum Role {
 }
 
 type UserIdentify {
-  sub: ID!
+  sub: ID
   microsoftUserId: String
 }
 
 type User {
   id: ID!
-  name: String!
-  email: String!
   identify: UserIdentify!
   role: Role!
   groups: [Group!]!

--- a/api/graph/model.resolvers.go
+++ b/api/graph/model.resolvers.go
@@ -6,7 +6,6 @@ package graph
 
 import (
 	"context"
-
 	"sports-day/api/db_model"
 	"sports-day/api/graph/model"
 	"sports-day/api/loader"
@@ -707,12 +706,16 @@ func (r *userResolver) Identify(ctx context.Context, obj *model.User) (*model.Us
 	if idp == nil {
 		return &model.UserIdentify{}, nil
 	}
+	var sub *string
+	if idp.Sub.Valid {
+		sub = &idp.Sub.String
+	}
 	var microsoftUserID *string
 	if idp.MicrosoftUserID.Valid {
 		microsoftUserID = &idp.MicrosoftUserID.String
 	}
 	return &model.UserIdentify{
-		Sub:             idp.Sub.String,
+		Sub:             sub,
 		MicrosoftUserID: microsoftUserID,
 	}, nil
 }
@@ -852,24 +855,3 @@ type tournamentResolver struct{ *Resolver }
 type tournamentRankingResolver struct{ *Resolver }
 type tournamentSlotResolver struct{ *Resolver }
 type userResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//    it when you're done.
-//  - You have helper methods in this file. Move them out to keep these resolver files clean.
-/*
-	func (r *competitionResolver) DisplayOrder(ctx context.Context, obj *model.Competition) (int32, error) {
-	return obj.DisplayOrder, nil
-}
-func (r *locationResolver) DisplayOrder(ctx context.Context, obj *model.Location) (int32, error) {
-	return obj.DisplayOrder, nil
-}
-func (r *sceneResolver) DisplayOrder(ctx context.Context, obj *model.Scene) (int32, error) {
-	return obj.DisplayOrder, nil
-}
-func (r *sportResolver) DisplayOrder(ctx context.Context, obj *model.Sport) (int32, error) {
-	return obj.DisplayOrder, nil
-}
-*/

--- a/api/graph/model/format_response.go
+++ b/api/graph/model/format_response.go
@@ -8,9 +8,7 @@ import (
 
 func FormatUserResponse(user *db_model.User) *User {
 	return &User{
-		ID:    user.ID,
-		Name:  user.Name.String,
-		Email: user.Email.String,
+		ID: user.ID,
 	}
 }
 

--- a/api/graph/model/models.go
+++ b/api/graph/model/models.go
@@ -6,9 +6,7 @@ type Group struct {
 }
 
 type User struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`
-	Email string `json:"email"`
+	ID string `json:"id"`
 }
 
 type Team struct {

--- a/api/graph/model/models_gen.go
+++ b/api/graph/model/models_gen.go
@@ -29,6 +29,15 @@ type AssignSeedTeamInput struct {
 	TeamID *string `json:"teamId,omitempty"`
 }
 
+// CSVインポート等でユーザーを一括作成するための入力
+type BatchCreateUsersInput struct {
+	Users []*CreateUserInput `json:"users"`
+}
+
+type BatchCreateUsersResult struct {
+	Users []*User `json:"users"`
+}
+
 type CreateCompetitionInput struct {
 	Name    string          `json:"name"`
 	Type    CompetitionType `json:"type"`
@@ -120,8 +129,8 @@ type CreateTournamentMatchInput struct {
 }
 
 type CreateUserInput struct {
-	Name  string `json:"name"`
-	Email string `json:"email"`
+	MicrosoftUserID string  `json:"microsoftUserId"`
+	GroupID         *string `json:"groupId,omitempty"`
 }
 
 type DeleteSportEntriesInput struct {
@@ -373,13 +382,8 @@ type UpdateTournamentInput struct {
 	DisplayOrder *int32  `json:"displayOrder,omitempty"`
 }
 
-type UpdateUserInput struct {
-	Name  *string `json:"name,omitempty"`
-	Email *string `json:"email,omitempty"`
-}
-
 type UserIdentify struct {
-	Sub             string  `json:"sub"`
+	Sub             *string `json:"sub,omitempty"`
 	MicrosoftUserID *string `json:"microsoftUserId,omitempty"`
 }
 

--- a/api/graph/schema.graphqls
+++ b/api/graph/schema.graphqls
@@ -1,14 +1,21 @@
 directive @hasPermission(permission: String!) on FIELD_DEFINITION
 
 input CreateUserInput {
-  name: String!
-  email: String!
+  microsoftUserId: String!
+  groupId: ID
 }
 
-input UpdateUserInput {
-  name: String
-  email: String
+"""
+CSVインポート等でユーザーを一括作成するための入力
+"""
+input BatchCreateUsersInput {
+  users: [CreateUserInput!]!
 }
+
+type BatchCreateUsersResult {
+  users: [User!]!
+}
+
 
 input CreateGroupInput {
   name: String!
@@ -434,7 +441,10 @@ type ImageUploadURL {
 
 type Mutation {
   createUser(input: CreateUserInput!): User! @hasPermission(permission: "user:write")
-  updateUser(id: ID!, input: UpdateUserInput!): User! @hasPermission(permission: "user:write")
+  """
+  ユーザーを一括作成する（CSV インポート用）
+  """
+  batchCreateUsers(input: BatchCreateUsersInput!): BatchCreateUsersResult! @hasPermission(permission: "user:write")
   deleteUser(id: ID!): User! @hasPermission(permission: "user:write")
   createGroup(input: CreateGroupInput!): Group! @hasPermission(permission: "group:write")
   deleteGroup(id: ID!): Group! @hasPermission(permission: "group:write")

--- a/api/graph/schema.resolvers.go
+++ b/api/graph/schema.resolvers.go
@@ -6,7 +6,6 @@ package graph
 
 import (
 	"context"
-
 	"sports-day/api/db_model"
 	"sports-day/api/graph/model"
 )
@@ -20,13 +19,19 @@ func (r *mutationResolver) CreateUser(ctx context.Context, input model.CreateUse
 	return model.FormatUserResponse(user), nil
 }
 
-// UpdateUser is the resolver for the updateUser field.
-func (r *mutationResolver) UpdateUser(ctx context.Context, id string, input model.UpdateUserInput) (*model.User, error) {
-	user, err := r.UserService.Update(ctx, id, &input)
+// BatchCreateUsers is the resolver for the batchCreateUsers field.
+func (r *mutationResolver) BatchCreateUsers(ctx context.Context, input model.BatchCreateUsersInput) (*model.BatchCreateUsersResult, error) {
+	users, err := r.UserService.BatchCreate(ctx, input.Users)
 	if err != nil {
 		return nil, err
 	}
-	return model.FormatUserResponse(user), nil
+	result := &model.BatchCreateUsersResult{
+		Users: make([]*model.User, len(users)),
+	}
+	for i, user := range users {
+		result.Users[i] = model.FormatUserResponse(user)
+	}
+	return result, nil
 }
 
 // DeleteUser is the resolver for the deleteUser field.

--- a/api/pkg/errors/error_code.go
+++ b/api/pkg/errors/error_code.go
@@ -27,6 +27,8 @@ var (
 	*/
 	ErrSaveUser                       = NewError("USER_SAVE_FAILED", "ユーザーの更新に失敗しました")
 	ErrSaveUserIdp                    = NewError("USER_IDP_SAVE_FAILED", "ユーザーIDP情報の更新に失敗しました")
+	ErrDuplicateMicrosoftUserID       = NewError("DUPLICATE_MICROSOFT_USER_ID", "同じMicrosoft User IDのユーザーが既に存在します")
+	ErrDuplicateMicrosoftUserIDInBatch = NewError("DUPLICATE_MICROSOFT_USER_ID_IN_BATCH", "バッチ内にMicrosoft User IDが重複しています")
 	ErrSaveTeam                       = NewError("TEAM_SAVE_FAILED", "チームの更新に失敗しました")
 	ErrAddTeamUser                    = NewError("TEAM_USER_ADD_FAILED", "チームユーザーの追加に失敗しました")
 	ErrDeleteTeamUser                 = NewError("TEAM_USER_REMOVE_FAILED", "チームユーザーの削除に失敗しました")

--- a/api/repository/user.go
+++ b/api/repository/user.go
@@ -14,11 +14,13 @@ type User interface {
 	BatchGet(ctx context.Context, db *gorm.DB, ids []string) ([]*db_model.User, error)
 	FindByEmail(ctx context.Context, db *gorm.DB, email string) (*db_model.User, error)
 	Save(ctx context.Context, db *gorm.DB, user *db_model.User) (*db_model.User, error)
+	BatchSave(ctx context.Context, db *gorm.DB, users []*db_model.User) ([]*db_model.User, error)
 	Delete(ctx context.Context, db *gorm.DB, id string) error
 	FindUserIdpBySub(ctx context.Context, db *gorm.DB, sub string) (*db_model.UsersIdp, error)
 	FindUserIdpByMicrosoftUserID(ctx context.Context, db *gorm.DB, microsoftUserID string) (*db_model.UsersIdp, error)
 	BatchFindUserIdpByUserIDs(ctx context.Context, db *gorm.DB, userIDs []string) ([]*db_model.UsersIdp, error)
 	SaveUserIdp(ctx context.Context, db *gorm.DB, userIdp *db_model.UsersIdp) (*db_model.UsersIdp, error)
+	BatchSaveUserIdp(ctx context.Context, db *gorm.DB, userIdps []*db_model.UsersIdp) ([]*db_model.UsersIdp, error)
 	GetRoleByUserID(ctx context.Context, db *gorm.DB, userID string) (*db_model.UserRole, error)
 	BatchGetRolesByUserIDs(ctx context.Context, db *gorm.DB, userIDs []string) ([]*db_model.UserRole, error)
 	SaveRole(ctx context.Context, db *gorm.DB, userRole *db_model.UserRole) (*db_model.UserRole, error)

--- a/api/repository/user_sql.go
+++ b/api/repository/user_sql.go
@@ -48,6 +48,16 @@ func (r user) Save(ctx context.Context, db *gorm.DB, user *db_model.User) (*db_m
 	return user, nil
 }
 
+func (r user) BatchSave(ctx context.Context, db *gorm.DB, users []*db_model.User) ([]*db_model.User, error) {
+	if len(users) == 0 {
+		return users, nil
+	}
+	if err := db.Create(&users).Error; err != nil {
+		return nil, errors.Wrap(err)
+	}
+	return users, nil
+}
+
 func (r user) Delete(ctx context.Context, db *gorm.DB, id string) error {
 	if err := db.Delete(&db_model.User{}, "id = ?", id).Error; err != nil {
 		return errors.Wrap(err)
@@ -98,6 +108,16 @@ func (r user) SaveUserIdp(ctx context.Context, db *gorm.DB, userIdp *db_model.Us
 		return nil, errors.Wrap(err)
 	}
 	return userIdp, nil
+}
+
+func (r user) BatchSaveUserIdp(ctx context.Context, db *gorm.DB, userIdps []*db_model.UsersIdp) ([]*db_model.UsersIdp, error) {
+	if len(userIdps) == 0 {
+		return userIdps, nil
+	}
+	if err := db.Create(&userIdps).Error; err != nil {
+		return nil, errors.Wrap(err)
+	}
+	return userIdps, nil
 }
 
 func (r user) GetRoleByUserID(ctx context.Context, db *gorm.DB, userID string) (*db_model.UserRole, error) {

--- a/api/service/user.go
+++ b/api/service/user.go
@@ -13,12 +13,13 @@ import (
 )
 
 type User struct {
-	db             *gorm.DB
-	userRepository repository.User
+	db              *gorm.DB
+	userRepository  repository.User
+	groupRepository repository.Group
 }
 
-func NewUser(db *gorm.DB, userRepository repository.User) User {
-	return User{db: db, userRepository: userRepository}
+func NewUser(db *gorm.DB, userRepository repository.User, groupRepository repository.Group) User {
+	return User{db: db, userRepository: userRepository, groupRepository: groupRepository}
 }
 
 func (s *User) Get(ctx context.Context, id string) (*db_model.User, error) {
@@ -38,35 +39,128 @@ func (s *User) List(ctx context.Context) ([]*db_model.User, error) {
 }
 
 func (s *User) Create(ctx context.Context, input *model.CreateUserInput) (*db_model.User, error) {
-	user := &db_model.User{ID: ulid.Make()}
-	user.Name.String = input.Name
-	user.Name.Valid = input.Name != ""
-	user.Email.String = input.Email
-	user.Email.Valid = input.Email != ""
-	row, err := s.userRepository.Save(ctx, s.db, user)
+	var result *db_model.User
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		user, err := s.createUserWithIdp(ctx, tx, input)
+		if err != nil {
+			return err
+		}
+		result = user
+		return nil
+	})
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
-	return row, nil
+	return result, nil
 }
 
-func (s *User) Update(ctx context.Context, id string, input *model.UpdateUserInput) (*db_model.User, error) {
-	user, err := s.userRepository.Get(ctx, s.db, id)
+// BatchCreate はユーザーを一括作成する（1トランザクション）
+func (s *User) BatchCreate(ctx context.Context, inputs []*model.CreateUserInput) ([]*db_model.User, error) {
+	// バッチ内の重複チェック
+	seenMsIds := make(map[string]struct{})
+	for _, input := range inputs {
+		if _, exists := seenMsIds[input.MicrosoftUserID]; exists {
+			return nil, errors.ErrDuplicateMicrosoftUserIDInBatch
+		}
+		seenMsIds[input.MicrosoftUserID] = struct{}{}
+	}
+
+	// DB上の既存ユーザーとの重複チェック
+	for _, input := range inputs {
+		_, err := s.userRepository.FindUserIdpByMicrosoftUserID(ctx, s.db, input.MicrosoftUserID)
+		if err == nil {
+			return nil, errors.ErrDuplicateMicrosoftUserID
+		}
+		if !errors.Is(err, errors.ErrUserNotFound) {
+			return nil, errors.Wrap(err)
+		}
+	}
+
+	// groupId の存在チェック
+	groupIdSet := make(map[string]struct{})
+	for _, input := range inputs {
+		if input.GroupID != nil {
+			groupIdSet[*input.GroupID] = struct{}{}
+		}
+	}
+	for gid := range groupIdSet {
+		if _, err := s.groupRepository.Get(ctx, s.db, gid); err != nil {
+			return nil, errors.ErrGroupNotFound
+		}
+	}
+
+	users := make([]*db_model.User, len(inputs))
+	idps := make([]*db_model.UsersIdp, len(inputs))
+	var groupUsers []*db_model.GroupUser
+
+	for i, input := range inputs {
+		id := ulid.Make()
+		users[i] = &db_model.User{ID: id}
+
+		idp := &db_model.UsersIdp{
+			UserID:   id,
+			Provider: "microsoft",
+		}
+		idp.MicrosoftUserID.String = input.MicrosoftUserID
+		idp.MicrosoftUserID.Valid = true
+		idps[i] = idp
+
+		if input.GroupID != nil {
+			groupUsers = append(groupUsers, &db_model.GroupUser{
+				GroupID: *input.GroupID,
+				UserID:  id,
+			})
+		}
+	}
+
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		if _, err := s.userRepository.BatchSave(ctx, tx, users); err != nil {
+			return errors.Wrap(err)
+		}
+		if _, err := s.userRepository.BatchSaveUserIdp(ctx, tx, idps); err != nil {
+			return errors.Wrap(err)
+		}
+		if len(groupUsers) > 0 {
+			if _, err := s.groupRepository.AddGroupUsers(ctx, tx, groupUsers); err != nil {
+				return errors.Wrap(err)
+			}
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
-	if input.Name != nil {
-		user.Name.String = *input.Name
-		user.Name.Valid = *input.Name != ""
-	}
-	if input.Email != nil {
-		user.Email.String = *input.Email
-		user.Email.Valid = *input.Email != ""
-	}
-	row, err := s.userRepository.Save(ctx, s.db, user)
+	return users, nil
+}
+
+// createUserWithIdp は1人分のユーザー + users_idp + group_users を作成する（トランザクション内で使用）
+func (s *User) createUserWithIdp(ctx context.Context, tx *gorm.DB, input *model.CreateUserInput) (*db_model.User, error) {
+	user := &db_model.User{ID: ulid.Make()}
+	row, err := s.userRepository.Save(ctx, tx, user)
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
+
+	idp := &db_model.UsersIdp{
+		UserID:   row.ID,
+		Provider: "microsoft",
+	}
+	idp.MicrosoftUserID.String = input.MicrosoftUserID
+	idp.MicrosoftUserID.Valid = true
+	if _, err := s.userRepository.SaveUserIdp(ctx, tx, idp); err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	if input.GroupID != nil {
+		entry := &db_model.GroupUser{
+			GroupID: *input.GroupID,
+			UserID:  row.ID,
+		}
+		if _, err := s.groupRepository.AddGroupUsers(ctx, tx, []*db_model.GroupUser{entry}); err != nil {
+			return nil, errors.Wrap(err)
+		}
+	}
+
 	return row, nil
 }
 

--- a/apps/admin/schema.graphqls
+++ b/apps/admin/schema.graphqls
@@ -5,14 +5,12 @@ enum Role {
 }
 
 type UserIdentify {
-  sub: ID!
+  sub: ID
   microsoftUserId: String
 }
 
 type User {
   id: ID!
-  name: String!
-  email: String!
   identify: UserIdentify!
   role: Role!
   groups: [Group!]!
@@ -271,14 +269,21 @@ type Rule {
 directive @hasPermission(permission: String!) on FIELD_DEFINITION
 
 input CreateUserInput {
-  name: String!
-  email: String!
+  microsoftUserId: String!
+  groupId: ID
 }
 
-input UpdateUserInput {
-  name: String
-  email: String
+"""
+CSVインポート等でユーザーを一括作成するための入力
+"""
+input BatchCreateUsersInput {
+  users: [CreateUserInput!]!
 }
+
+type BatchCreateUsersResult {
+  users: [User!]!
+}
+
 
 input CreateGroupInput {
   name: String!
@@ -704,7 +709,10 @@ type ImageUploadURL {
 
 type Mutation {
   createUser(input: CreateUserInput!): User! @hasPermission(permission: "user:write")
-  updateUser(id: ID!, input: UpdateUserInput!): User! @hasPermission(permission: "user:write")
+  """
+  ユーザーを一括作成する（CSV インポート用）
+  """
+  batchCreateUsers(input: BatchCreateUsersInput!): BatchCreateUsersResult! @hasPermission(permission: "user:write")
   deleteUser(id: ID!): User! @hasPermission(permission: "user:write")
   createGroup(input: CreateGroupInput!): Group! @hasPermission(permission: "group:write")
   deleteGroup(id: ID!): Group! @hasPermission(permission: "group:write")

--- a/apps/admin/src/features/classes/api.ts
+++ b/apps/admin/src/features/classes/api.ts
@@ -18,7 +18,7 @@ export const GET_ADMIN_GROUP_FOR_CLASS = gql`
     group(id: $id) {
       id
       name
-      users { id name email }
+      users { id identify { microsoftUserId } }
     }
   }
 `
@@ -53,7 +53,7 @@ export const ADD_ADMIN_GROUP_USERS_FOR_CLASS = gql`
   mutation AddAdminGroupUsersForClass($id: ID!, $input: UpdateGroupUsersInput!) {
     addGroupUsers(id: $id, input: $input) {
       id
-      users { id name email }
+      users { id identify { microsoftUserId } }
     }
   }
 `
@@ -62,7 +62,7 @@ export const REMOVE_ADMIN_GROUP_USERS_FOR_CLASS = gql`
   mutation RemoveAdminGroupUsersForClass($id: ID!, $input: UpdateGroupUsersInput!) {
     removeGroupUsers(id: $id, input: $input) {
       id
-      users { id name email }
+      users { id identify { microsoftUserId } }
     }
   }
 `

--- a/apps/admin/src/features/classes/hooks/useClassDetail.ts
+++ b/apps/admin/src/features/classes/hooks/useClassDetail.ts
@@ -52,8 +52,8 @@ export function useClassDetail(classId: string) {
     const msUser = msId ? msGraphUsers.get(msId) : undefined
     return {
       id: u.id,
-      name: msUser?.displayName ?? u.name,
-      email: msUser?.mail ?? u.email,
+      name: msUser?.displayName ?? '',
+      email: msUser?.mail ?? '',
     }
   })
 
@@ -108,8 +108,8 @@ export function useClassDetail(classId: string) {
       const msUser = msId ? msGraphUsers.get(msId) : undefined
       return {
         id: u.id,
-        userName: msUser?.displayName ?? u.name,
-        email: msUser?.mail ?? u.email,
+        userName: msUser?.displayName ?? '',
+        email: msUser?.mail ?? '',
       }
     })
 

--- a/apps/admin/src/features/competitions/hooks/useAddEntryTeams.ts
+++ b/apps/admin/src/features/competitions/hooks/useAddEntryTeams.ts
@@ -28,7 +28,7 @@ export function useAddEntryTeams(sportId: string) {
     return (teamsData?.teams ?? []).map(t => {
       const members: EntryTeamMember[] = (t.users ?? []).map(u => ({
         id: u.id,
-        name: u.name,
+        name: '',
         isExperienced: sportId ? experiencedUserIds.has(u.id) : false,
       }))
       return {

--- a/apps/admin/src/features/competitions/hooks/useCompetitionPdfData.ts
+++ b/apps/admin/src/features/competitions/hooks/useCompetitionPdfData.ts
@@ -120,7 +120,7 @@ export function useCompetitionPdfData(sportId: string, sceneId: string, skip = f
             id: t.id,
             name: t.name,
             groupName: t.group.name,
-            members: t.users.map((u) => ({ id: u.id, name: u.name })),
+            members: t.users.map((u) => ({ id: u.id, name: '' })),
           }
         })
         .filter((t): t is PdfTeam => t !== null)

--- a/apps/admin/src/features/matches/api.ts
+++ b/apps/admin/src/features/matches/api.ts
@@ -55,7 +55,7 @@ export const GET_ADMIN_MATCH = gql`
       location { id name }
       competition { id name }
       entries { id team { id name } score }
-      judgment { id name isAttending user { id name } team { id name } group { id name } }
+      judgment { id name isAttending user { id identify { microsoftUserId } } team { id name } group { id name } }
     }
   }
 `
@@ -124,7 +124,7 @@ export const UPDATE_ADMIN_JUDGMENT = gql`
     updateJudgment(id: $id, input: $input) {
       id
       name
-      user { id name }
+      user { id identify { microsoftUserId } }
       team { id name }
       group { id name }
     }
@@ -169,7 +169,7 @@ export const GET_ADMIN_COMPETITION_JUDGE_OPTIONS = gql`
         id
         name
         group { id name }
-        users { id name }
+        users { id identify { microsoftUserId } }
       }
     }
   }

--- a/apps/admin/src/features/matches/components/MatchEditPage.tsx
+++ b/apps/admin/src/features/matches/components/MatchEditPage.tsx
@@ -97,8 +97,7 @@ export function MatchEditPage({ match, teamA, teamB, context, form, nav, onReset
   const matchDetail = matchData?.match
 
   const infoTags = useMemo(() => {
-    const judgmentLabel = matchDetail?.judgment?.user?.name
-      ?? matchDetail?.judgment?.team?.name
+    const judgmentLabel = matchDetail?.judgment?.team?.name
       ?? matchDetail?.judgment?.group?.name
       ?? matchDetail?.judgment?.name
       ?? '未登録'

--- a/apps/admin/src/features/matches/hooks/useMatchDetails.ts
+++ b/apps/admin/src/features/matches/hooks/useMatchDetails.ts
@@ -109,7 +109,7 @@ export function useMatchDetails(match: ActiveMatch, competitionId?: string) {
   const currentJudgmentLabel = useMemo(() => {
     const j = matchData?.match?.judgment
     if (!j) return undefined
-    return j.user?.name ?? j.team?.name ?? j.group?.name ?? j.name ?? undefined
+    return j.team?.name ?? j.group?.name ?? j.name ?? undefined
   }, [matchData])
 
   const handleSave = async () => {

--- a/apps/admin/src/features/teams/api.ts
+++ b/apps/admin/src/features/teams/api.ts
@@ -6,7 +6,7 @@ export const GET_ADMIN_TEAMS = gql`
       id
       name
       group { id name }
-      users { id name email }
+      users { id identify { microsoftUserId } }
     }
   }
 `
@@ -17,7 +17,7 @@ export const GET_ADMIN_TEAM = gql`
       id
       name
       group { id name }
-      users { id name email }
+      users { id identify { microsoftUserId } }
     }
   }
 `
@@ -54,7 +54,7 @@ export const UPDATE_ADMIN_TEAM_USERS = gql`
   mutation UpdateAdminTeamUsers($id: ID!, $input: UpdateTeamUsersInput!) {
     updateTeamUsers(id: $id, input: $input) {
       id
-      users { id name email }
+      users { id identify { microsoftUserId } }
     }
   }
 `

--- a/apps/admin/src/features/teams/components/AddMemberDialog.tsx
+++ b/apps/admin/src/features/teams/components/AddMemberDialog.tsx
@@ -41,8 +41,8 @@ export function AddMemberDialog({ open, onClose, onAdd }: Props) {
       : undefined
     return {
       id: u.id,
-      userName: msUser?.displayName ?? u.name,
-      email: msUser?.mail ?? u.email,
+      userName: msUser?.displayName ?? '',
+      email: msUser?.mail ?? '',
     }
   })
 

--- a/apps/admin/src/features/teams/hooks/useTeamDetail.ts
+++ b/apps/admin/src/features/teams/hooks/useTeamDetail.ts
@@ -61,7 +61,7 @@ export function useTeamDetail(teamId: string) {
     const msUser = msId ? msGraphUsers.get(msId) : undefined
     return {
       id: u.id,
-      name: msUser?.displayName ?? u.name,
+      name: msUser?.displayName ?? '',
     }
   })
 
@@ -152,7 +152,7 @@ export function useTeamDetail(teamId: string) {
       const msUser = msId ? msGraphUsers.get(msId) : undefined
       return {
         id: u.id,
-        userName: msUser?.displayName ?? u.name,
+        userName: msUser?.displayName ?? '',
       }
     })
 

--- a/apps/admin/src/features/users/api.ts
+++ b/apps/admin/src/features/users/api.ts
@@ -4,8 +4,6 @@ export const GET_ADMIN_USERS = gql`
   query GetAdminUsers {
     users {
       id
-      name
-      email
       role
       identify { microsoftUserId }
       groups { id name }
@@ -26,8 +24,6 @@ export const GET_ADMIN_USER = gql`
   query GetAdminUser($id: ID!) {
     user(id: $id) {
       id
-      name
-      email
       role
       identify { microsoftUserId }
       groups { id name }
@@ -38,20 +34,16 @@ export const GET_ADMIN_USER = gql`
 
 export const CREATE_ADMIN_USER = gql`
   mutation CreateAdminUser($input: CreateUserInput!) {
-    createUser(input: $input) {
-      id
-      name
-      email
-    }
+    createUser(input: $input) { id }
   }
 `
 
-export const UPDATE_ADMIN_USER = gql`
-  mutation UpdateAdminUser($id: ID!, $input: UpdateUserInput!) {
-    updateUser(id: $id, input: $input) {
-      id
-      name
-      email
+export const BATCH_CREATE_ADMIN_USERS = gql`
+  mutation BatchCreateAdminUsers($input: BatchCreateUsersInput!) {
+    batchCreateUsers(input: $input) {
+      users {
+        id
+      }
     }
   }
 `

--- a/apps/admin/src/features/users/components/UserCsvPage.tsx
+++ b/apps/admin/src/features/users/components/UserCsvPage.tsx
@@ -10,6 +10,7 @@ import {
   TableRow,
   TextField,
   Typography,
+  CircularProgress,
 } from '@mui/material'
 import { BackButton } from '@/components/ui/BackButton'
 import { useUserCsv } from '../hooks/useUserCsv'
@@ -41,10 +42,17 @@ type Props = {
 }
 
 export function UserCsvPage({ onBack }: Props) {
-  const { csvText, handleCsvChange, rows, handleCreate } = useUserCsv()
+  const { csvText, handleCsvChange, rows, resolveUsers, handleCreate, loading } = useUserCsv()
 
-  const onCreateClick = () => {
-    handleCreate()
+  const hasUnresolved = rows.some((r) => r.status === '確認中')
+  const hasRegistrable = rows.some((r) => r.status === '登録可能')
+
+  const onResolveClick = async () => {
+    await resolveUsers()
+  }
+
+  const onCreateClick = async () => {
+    await handleCreate()
     showToast('ユーザーを一括作成しました')
     onBack()
   }
@@ -75,18 +83,19 @@ export function UserCsvPage({ onBack }: Props) {
         </Typography>
 
         <Typography sx={{ fontSize: '13px', color: '#2F3C8C', mb: 2, lineHeight: 1.8 }}>
-          追加するユーザー一覧のCSVファイルと所属クラスを選択してください。<br />
-          所属クラスを指定してください。<br />
-          CSVを入力してください。
+          メールアドレスとクラス名のCSVを入力してください。<br />
+          形式: メールアドレス,クラス名
         </Typography>
 
         {/* CSV入力 */}
         <TextField
           fullWidth
+          multiline
+          minRows={4}
           size="small"
           value={csvText}
           onChange={(e) => handleCsvChange(e.target.value)}
-          placeholder="CSVデータ"
+          placeholder={'user1@example.com,1組\nuser2@example.com,2組'}
           sx={{
             mb: 2,
             '& .MuiOutlinedInput-root': {
@@ -100,11 +109,29 @@ export function UserCsvPage({ onBack }: Props) {
           }}
         />
 
+        {/* ユーザー確認ボタン */}
+        {hasUnresolved && (
+          <Button
+            variant="outlined"
+            fullWidth
+            onClick={onResolveClick}
+            disabled={loading}
+            sx={{
+              mb: 2,
+              height: '40px',
+              borderRadius: 2,
+              color: '#2F3C8C',
+              borderColor: '#5B6DC6',
+            }}
+          >
+            {loading ? <CircularProgress size={20} /> : 'ユーザーを確認'}
+          </Button>
+        )}
+
         {/* テーブル */}
         <Table size="small" sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflow: 'hidden' }}>
           <TableHead>
             <TableRow>
-              <TableCell sx={TABLE_HEAD_SX}>ユーザー名</TableCell>
               <TableCell sx={TABLE_HEAD_SX}>メールアドレス</TableCell>
               <TableCell sx={TABLE_HEAD_SX}>クラス</TableCell>
               <TableCell sx={TABLE_HEAD_SX}>ステータス</TableCell>
@@ -114,7 +141,7 @@ export function UserCsvPage({ onBack }: Props) {
             {rows.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={4}
+                  colSpan={3}
                   sx={{ textAlign: 'center', color: '#9E9E9E', py: 4, fontSize: '13px', backgroundColor: '#FFFFFF' }}
                 >
                   No Rows To Show
@@ -122,10 +149,9 @@ export function UserCsvPage({ onBack }: Props) {
               </TableRow>
             ) : (
               rows.map((row, i) => {
-                const hasError = row.status !== '登録可能'
+                const hasError = row.status !== '登録可能' && row.status !== '確認中'
                 return (
                   <TableRow key={i} hover sx={{ '&:hover': { backgroundColor: '#E5E6F0' } }}>
-                    <TableCell sx={TABLE_CELL_SX}>{row.userName}</TableCell>
                     <TableCell sx={hasError ? ERROR_CELL_SX : TABLE_CELL_SX}>{row.email}</TableCell>
                     <TableCell sx={hasError ? ERROR_CELL_SX : TABLE_CELL_SX}>{row.class}</TableCell>
                     <TableCell sx={hasError ? ERROR_CELL_SX : TABLE_CELL_SX}>{row.status}</TableCell>
@@ -142,6 +168,7 @@ export function UserCsvPage({ onBack }: Props) {
         variant="contained"
         fullWidth
         onClick={onCreateClick}
+        disabled={!hasRegistrable || loading}
         sx={{
           ...SAVE_BUTTON_SX,
           height: '48px',

--- a/apps/admin/src/features/users/hooks/useUserCsv.ts
+++ b/apps/admin/src/features/users/hooks/useUserCsv.ts
@@ -1,64 +1,119 @@
 import { useState } from 'react'
 import Papa from 'papaparse'
 import {
-  useGetAdminUsersQuery,
-  useCreateAdminUserMutation,
+  useGetAdminGroupsForClassesQuery,
+  useBatchCreateAdminUsersMutation,
 } from '@/gql/__generated__/graphql'
+import { userManager } from '@/lib/userManager'
+import { fetchMsGraphUsersByEmails } from '@/lib/graphApi'
 import { showErrorToast } from '@/lib/toast'
 
 export type UserCsvRow = {
-  userName: string
   email: string
   class: string
+  microsoftUserId: string | null
   status: string
 }
 
 export function useUserCsv() {
   const [csvText, setCsvText] = useState('')
   const [rows, setRows] = useState<UserCsvRow[]>([])
+  const [loading, setLoading] = useState(false)
   const [mutationError, setMutationError] = useState<Error | null>(null)
 
-  const { data: usersData } = useGetAdminUsersQuery()
-  const [createUser] = useCreateAdminUserMutation()
+  const { data: groupsData } = useGetAdminGroupsForClassesQuery()
+  const [batchCreateUsers] = useBatchCreateAdminUsersMutation()
 
   const handleCsvChange = (value: string) => {
     setCsvText(value)
 
-    const existingEmails = new Set((usersData?.users ?? []).map(u => u.email))
     const seenEmails = new Set<string>()
-
     const result = Papa.parse<string[]>(value, { skipEmptyLines: true })
     const parsed: UserCsvRow[] = result.data.map((parts) => {
-      const userName = (parts[0] ?? '').trim()
-      const email = (parts[1] ?? '').trim()
-      const cls = (parts[2] ?? '').trim()
+      const email = (parts[0] ?? '').trim()
+      const cls = (parts[1] ?? '').trim()
 
-      if (!userName) return { userName, email, class: cls, status: '名前が空です' }
-      if (!email) return { userName, email, class: cls, status: 'メールが空です' }
-      if (existingEmails.has(email)) return { userName, email, class: cls, status: 'メールが重複しています（既存）' }
-      if (seenEmails.has(email)) return { userName, email, class: cls, status: 'メールが重複しています（CSV内）' }
+      if (!email) return { email, class: cls, microsoftUserId: null, status: 'メールが空です' }
+      if (!cls) return { email, class: cls, microsoftUserId: null, status: 'クラスが空です' }
+      if (seenEmails.has(email.toLowerCase()))
+        return { email, class: cls, microsoftUserId: null, status: 'メールが重複しています（CSV内）' }
 
-      seenEmails.add(email)
-      return { userName, email, class: cls, status: '登録可能' }
+      seenEmails.add(email.toLowerCase())
+      return { email, class: cls, microsoftUserId: null, status: '確認中' }
     })
 
     setRows(parsed)
   }
 
-  const handleCreate = async () => {
-    const registrable = rows.filter((r) => r.status === '登録可能')
+  const resolveUsers = async () => {
+    const pendingRows = rows.filter((r) => r.status === '確認中')
+    if (pendingRows.length === 0) return
+
+    setLoading(true)
     try {
-      for (const r of registrable) {
-        await createUser({
-          variables: {
-            input: {
-              name: r.userName,
-              email: r.email,
-            },
-          },
-          refetchQueries: ['GetAdminUsers'],
-        })
+      const user = await userManager.getUser()
+      if (!user?.access_token) {
+        setRows((prev) =>
+          prev.map((r) =>
+            r.status === '確認中' ? { ...r, status: 'アクセストークン取得失敗' } : r,
+          ),
+        )
+        return
       }
+
+      const emails = pendingRows.map((r) => r.email)
+      const msUsers = await fetchMsGraphUsersByEmails(user.access_token, emails)
+
+      const groups = groupsData?.groups ?? []
+      const groupNameToId = new Map(groups.map((g) => [g.name, g.id]))
+
+      setRows((prev) =>
+        prev.map((r) => {
+          if (r.status !== '確認中') return r
+
+          const msUser = msUsers.get(r.email.toLowerCase())
+          if (!msUser) {
+            return { ...r, status: 'テナントにユーザーが見つかりません' }
+          }
+
+          if (!groupNameToId.has(r.class)) {
+            return { ...r, microsoftUserId: msUser.id, status: `クラス「${r.class}」が存在しません` }
+          }
+
+          return { ...r, microsoftUserId: msUser.id, status: '登録可能' }
+        }),
+      )
+    } catch (e) {
+      console.error('Graph API resolve failed:', e)
+      setRows((prev) =>
+        prev.map((r) =>
+          r.status === '確認中' ? { ...r, status: 'Graph API エラー' } : r,
+        ),
+      )
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleCreate = async () => {
+    const groups = groupsData?.groups ?? []
+    const groupNameToId = new Map(groups.map((g) => [g.name, g.id]))
+
+    const registrable = rows.filter((r) => r.status === '登録可能' && r.microsoftUserId)
+    if (registrable.length === 0) return
+
+    try {
+      await batchCreateUsers({
+        variables: {
+          input: {
+            users: registrable.map((r) => ({
+              microsoftUserId: r.microsoftUserId!,
+              groupId: groupNameToId.get(r.class),
+            })),
+          },
+        },
+        refetchQueries: ['GetAdminUsers'],
+      })
       setMutationError(null)
       setCsvText('')
       setRows([])
@@ -68,5 +123,5 @@ export function useUserCsv() {
     }
   }
 
-  return { csvText, handleCsvChange, rows, handleCreate, error: mutationError }
+  return { csvText, handleCsvChange, rows, resolveUsers, handleCreate, loading, error: mutationError }
 }

--- a/apps/admin/src/features/users/hooks/useUserDetail.ts
+++ b/apps/admin/src/features/users/hooks/useUserDetail.ts
@@ -3,7 +3,6 @@ import {
   Role,
   useGetAdminUserQuery,
   useGetAdminGroupsQuery,
-  useUpdateAdminUserMutation,
   useUpdateAdminUserRoleMutation,
   useDeleteAdminUserMutation,
   useGetAdminUserSportExperiencesQuery,
@@ -69,10 +68,6 @@ export function useUserDetail(userId: string) {
     role !== initialState.current.role ||
     JSON.stringify([...experiencedSportIds].sort()) !== JSON.stringify([...initialState.current.experiencedSportIds].sort())
 
-  const [updateUser] = useUpdateAdminUserMutation({
-    refetchQueries: [{ query: GetAdminUsersDocument }],
-  })
-
   const [updateUserRole] = useUpdateAdminUserRoleMutation({
     refetchQueries: [{ query: GetAdminUsersDocument }],
   })
@@ -90,15 +85,6 @@ export function useUserDetail(userId: string) {
 
   const handleSave = async () => {
     if (!userId) return
-    await updateUser({
-      variables: {
-        id: userId,
-        input: {
-          name: user?.name,
-          email: user?.email,
-        },
-      },
-    })
     if (user && role && role !== user.role) {
       await updateUserRole({
         variables: { userId, role: role as Role },
@@ -126,8 +112,8 @@ export function useUserDetail(userId: string) {
   }
 
   return {
-    userName: msGraphUser?.displayName ?? user?.name ?? '',
-    userEmail: msGraphUser?.mail ?? user?.email ?? '',
+    userName: msGraphUser?.displayName ?? '',
+    userEmail: msGraphUser?.mail ?? '',
     groupId,
     setGroupId,
     groups,

--- a/apps/admin/src/features/users/hooks/useUsers.ts
+++ b/apps/admin/src/features/users/hooks/useUsers.ts
@@ -41,8 +41,8 @@ export function useUsers() {
       : undefined
     return {
       id: u.id,
-      name: msUser?.displayName ?? u.name,
-      email: msUser?.mail ?? u.email,
+      name: msUser?.displayName ?? '',
+      email: msUser?.mail ?? '',
       role: u.role,
       groupName: u.groups[0]?.name ?? '',
       teams: u.teams.map((t) => ({ id: t.id, name: t.name })),

--- a/apps/admin/src/gql/__generated__/graphql.ts
+++ b/apps/admin/src/gql/__generated__/graphql.ts
@@ -38,6 +38,16 @@ export type AssignSeedTeamInput = {
   teamId?: InputMaybe<Scalars['ID']['input']>;
 };
 
+/** CSVインポート等でユーザーを一括作成するための入力 */
+export type BatchCreateUsersInput = {
+  users: Array<CreateUserInput>;
+};
+
+export type BatchCreateUsersResult = {
+  __typename?: 'BatchCreateUsersResult';
+  users: Array<User>;
+};
+
 export const BracketState = {
   Building: 'BUILDING',
   Completed: 'COMPLETED',
@@ -167,8 +177,8 @@ export type CreateTournamentMatchInput = {
 };
 
 export type CreateUserInput = {
-  email: Scalars['String']['input'];
-  name: Scalars['String']['input'];
+  groupId?: InputMaybe<Scalars['ID']['input']>;
+  microsoftUserId: Scalars['String']['input'];
 };
 
 export type DeleteSportEntriesInput = {
@@ -329,6 +339,8 @@ export type Mutation = {
   applyCompetitionDefaults: Array<Match>;
   /** SEEDスロットへのチーム手動配置（teamId=null でクリア） */
   assignSeedTeam: TournamentSlot;
+  /** ユーザーを一括作成する（CSV インポート用） */
+  batchCreateUsers: BatchCreateUsersResult;
   /** 大会を作成する */
   createCompetition: Competition;
   createGroup: Group;
@@ -449,7 +461,6 @@ export type Mutation = {
   updateTeamUsers: Team;
   /** トーナメント（ブラケット）を更新する */
   updateTournament: Tournament;
-  updateUser: User;
   /** ユーザーのロールを更新する（user:manage パーミッションが必要） */
   updateUserRole: User;
 };
@@ -499,6 +510,11 @@ export type MutationApplyCompetitionDefaultsArgs = {
 
 export type MutationAssignSeedTeamArgs = {
   input: AssignSeedTeamInput;
+};
+
+
+export type MutationBatchCreateUsersArgs = {
+  input: BatchCreateUsersInput;
 };
 
 
@@ -885,12 +901,6 @@ export type MutationUpdateTeamUsersArgs = {
 export type MutationUpdateTournamentArgs = {
   id: Scalars['ID']['input'];
   input: UpdateTournamentInput;
-};
-
-
-export type MutationUpdateUserArgs = {
-  id: Scalars['ID']['input'];
-  input: UpdateUserInput;
 };
 
 
@@ -1371,19 +1381,12 @@ export type UpdateTournamentInput = {
   name?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type UpdateUserInput = {
-  email?: InputMaybe<Scalars['String']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-};
-
 export type User = {
   __typename?: 'User';
-  email: Scalars['String']['output'];
   groups: Array<Group>;
   id: Scalars['ID']['output'];
   identify: UserIdentify;
   judgments: Array<Judgment>;
-  name: Scalars['String']['output'];
   role: Role;
   teams: Array<Team>;
 };
@@ -1391,7 +1394,7 @@ export type User = {
 export type UserIdentify = {
   __typename?: 'UserIdentify';
   microsoftUserId?: Maybe<Scalars['String']['output']>;
-  sub: Scalars['ID']['output'];
+  sub?: Maybe<Scalars['ID']['output']>;
 };
 
 export type GetAdminGroupsForClassesQueryVariables = Exact<{ [key: string]: never; }>;
@@ -1404,7 +1407,7 @@ export type GetAdminGroupForClassQueryVariables = Exact<{
 }>;
 
 
-export type GetAdminGroupForClassQuery = { __typename?: 'Query', group: { __typename?: 'Group', id: string, name: string, users: Array<{ __typename?: 'User', id: string, name: string, email: string }> } };
+export type GetAdminGroupForClassQuery = { __typename?: 'Query', group: { __typename?: 'Group', id: string, name: string, users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } };
 
 export type CreateAdminGroupForClassMutationVariables = Exact<{
   input: CreateGroupInput;
@@ -1434,7 +1437,7 @@ export type AddAdminGroupUsersForClassMutationVariables = Exact<{
 }>;
 
 
-export type AddAdminGroupUsersForClassMutation = { __typename?: 'Mutation', addGroupUsers: { __typename?: 'Group', id: string, users: Array<{ __typename?: 'User', id: string, name: string, email: string }> } };
+export type AddAdminGroupUsersForClassMutation = { __typename?: 'Mutation', addGroupUsers: { __typename?: 'Group', id: string, users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } };
 
 export type RemoveAdminGroupUsersForClassMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -1442,7 +1445,7 @@ export type RemoveAdminGroupUsersForClassMutationVariables = Exact<{
 }>;
 
 
-export type RemoveAdminGroupUsersForClassMutation = { __typename?: 'Mutation', removeGroupUsers: { __typename?: 'Group', id: string, users: Array<{ __typename?: 'User', id: string, name: string, email: string }> } };
+export type RemoveAdminGroupUsersForClassMutation = { __typename?: 'Mutation', removeGroupUsers: { __typename?: 'Group', id: string, users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } };
 
 export type GetAdminCompetitionsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1815,7 +1818,7 @@ export type GetAdminMatchQueryVariables = Exact<{
 }>;
 
 
-export type GetAdminMatchQuery = { __typename?: 'Query', match: { __typename?: 'Match', id: string, time: string, status: MatchStatus, location?: { __typename?: 'Location', id: string, name: string } | null, competition: { __typename?: 'Competition', id: string, name: string }, entries: Array<{ __typename?: 'MatchEntry', id: string, score: number, team?: { __typename?: 'Team', id: string, name: string } | null }>, judgment?: { __typename?: 'Judgment', id: string, name?: string | null, isAttending: boolean, user?: { __typename?: 'User', id: string, name: string } | null, team?: { __typename?: 'Team', id: string, name: string } | null, group?: { __typename?: 'Group', id: string, name: string } | null } | null } };
+export type GetAdminMatchQuery = { __typename?: 'Query', match: { __typename?: 'Match', id: string, time: string, status: MatchStatus, location?: { __typename?: 'Location', id: string, name: string } | null, competition: { __typename?: 'Competition', id: string, name: string }, entries: Array<{ __typename?: 'MatchEntry', id: string, score: number, team?: { __typename?: 'Team', id: string, name: string } | null }>, judgment?: { __typename?: 'Judgment', id: string, name?: string | null, isAttending: boolean, user?: { __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } } | null, team?: { __typename?: 'Team', id: string, name: string } | null, group?: { __typename?: 'Group', id: string, name: string } | null } | null } };
 
 export type UpdateAdminMatchResultMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -1869,7 +1872,7 @@ export type UpdateAdminJudgmentMutationVariables = Exact<{
 }>;
 
 
-export type UpdateAdminJudgmentMutation = { __typename?: 'Mutation', updateJudgment: { __typename?: 'Judgment', id: string, name?: string | null, user?: { __typename?: 'User', id: string, name: string } | null, team?: { __typename?: 'Team', id: string, name: string } | null, group?: { __typename?: 'Group', id: string, name: string } | null } };
+export type UpdateAdminJudgmentMutation = { __typename?: 'Mutation', updateJudgment: { __typename?: 'Judgment', id: string, name?: string | null, user?: { __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } } | null, team?: { __typename?: 'Team', id: string, name: string } | null, group?: { __typename?: 'Group', id: string, name: string } | null } };
 
 export type CreateAdminTournamentMatchMutationVariables = Exact<{
   input: CreateTournamentMatchInput;
@@ -1897,7 +1900,7 @@ export type GetAdminCompetitionJudgeOptionsQueryVariables = Exact<{
 }>;
 
 
-export type GetAdminCompetitionJudgeOptionsQuery = { __typename?: 'Query', competition: { __typename?: 'Competition', id: string, teams: Array<{ __typename?: 'Team', id: string, name: string, group: { __typename?: 'Group', id: string, name: string }, users: Array<{ __typename?: 'User', id: string, name: string }> }> } };
+export type GetAdminCompetitionJudgeOptionsQuery = { __typename?: 'Query', competition: { __typename?: 'Competition', id: string, teams: Array<{ __typename?: 'Team', id: string, name: string, group: { __typename?: 'Group', id: string, name: string }, users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> }> } };
 
 export type SetAdminTiebreakPrioritiesMutationVariables = Exact<{
   leagueId: Scalars['ID']['input'];
@@ -2049,14 +2052,14 @@ export type UpdateAdminScenesDisplayOrderMutation = { __typename?: 'Mutation', u
 export type GetAdminTeamsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAdminTeamsQuery = { __typename?: 'Query', teams: Array<{ __typename?: 'Team', id: string, name: string, group: { __typename?: 'Group', id: string, name: string }, users: Array<{ __typename?: 'User', id: string, name: string, email: string }> }> };
+export type GetAdminTeamsQuery = { __typename?: 'Query', teams: Array<{ __typename?: 'Team', id: string, name: string, group: { __typename?: 'Group', id: string, name: string }, users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> }> };
 
 export type GetAdminTeamQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetAdminTeamQuery = { __typename?: 'Query', team: { __typename?: 'Team', id: string, name: string, group: { __typename?: 'Group', id: string, name: string }, users: Array<{ __typename?: 'User', id: string, name: string, email: string }> } };
+export type GetAdminTeamQuery = { __typename?: 'Query', team: { __typename?: 'Team', id: string, name: string, group: { __typename?: 'Group', id: string, name: string }, users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } };
 
 export type CreateAdminTeamMutationVariables = Exact<{
   input: CreateTeamInput;
@@ -2086,7 +2089,7 @@ export type UpdateAdminTeamUsersMutationVariables = Exact<{
 }>;
 
 
-export type UpdateAdminTeamUsersMutation = { __typename?: 'Mutation', updateTeamUsers: { __typename?: 'Team', id: string, users: Array<{ __typename?: 'User', id: string, name: string, email: string }> } };
+export type UpdateAdminTeamUsersMutation = { __typename?: 'Mutation', updateTeamUsers: { __typename?: 'Team', id: string, users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } };
 
 export type GetAdminGroupsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -2096,29 +2099,28 @@ export type GetAdminGroupsQuery = { __typename?: 'Query', groups: Array<{ __type
 export type GetAdminUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAdminUsersQuery = { __typename?: 'Query', users: Array<{ __typename?: 'User', id: string, name: string, email: string, role: Role, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null }, groups: Array<{ __typename?: 'Group', id: string, name: string }>, teams: Array<{ __typename?: 'Team', id: string, name: string }> }>, sports: Array<{ __typename?: 'Sport', id: string, name: string }>, allSportExperiences: Array<{ __typename?: 'SportExperience', userId: string, sportId: string }> };
+export type GetAdminUsersQuery = { __typename?: 'Query', users: Array<{ __typename?: 'User', id: string, role: Role, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null }, groups: Array<{ __typename?: 'Group', id: string, name: string }>, teams: Array<{ __typename?: 'Team', id: string, name: string }> }>, sports: Array<{ __typename?: 'Sport', id: string, name: string }>, allSportExperiences: Array<{ __typename?: 'SportExperience', userId: string, sportId: string }> };
 
 export type GetAdminUserQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetAdminUserQuery = { __typename?: 'Query', user: { __typename?: 'User', id: string, name: string, email: string, role: Role, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null }, groups: Array<{ __typename?: 'Group', id: string, name: string }>, teams: Array<{ __typename?: 'Team', id: string, name: string }> } };
+export type GetAdminUserQuery = { __typename?: 'Query', user: { __typename?: 'User', id: string, role: Role, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null }, groups: Array<{ __typename?: 'Group', id: string, name: string }>, teams: Array<{ __typename?: 'Team', id: string, name: string }> } };
 
 export type CreateAdminUserMutationVariables = Exact<{
   input: CreateUserInput;
 }>;
 
 
-export type CreateAdminUserMutation = { __typename?: 'Mutation', createUser: { __typename?: 'User', id: string, name: string, email: string } };
+export type CreateAdminUserMutation = { __typename?: 'Mutation', createUser: { __typename?: 'User', id: string } };
 
-export type UpdateAdminUserMutationVariables = Exact<{
-  id: Scalars['ID']['input'];
-  input: UpdateUserInput;
+export type BatchCreateAdminUsersMutationVariables = Exact<{
+  input: BatchCreateUsersInput;
 }>;
 
 
-export type UpdateAdminUserMutation = { __typename?: 'Mutation', updateUser: { __typename?: 'User', id: string, name: string, email: string } };
+export type BatchCreateAdminUsersMutation = { __typename?: 'Mutation', batchCreateUsers: { __typename?: 'BatchCreateUsersResult', users: Array<{ __typename?: 'User', id: string }> } };
 
 export type DeleteAdminUserMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -2161,7 +2163,7 @@ export type DeleteAdminSportExperiencesMutation = { __typename?: 'Mutation', del
 export type GetMeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetMeQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string, name: string, role: Role } };
+export type GetMeQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string, role: Role, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } } };
 
 
 export const GetAdminGroupsForClassesDocument = gql`
@@ -2214,8 +2216,9 @@ export const GetAdminGroupForClassDocument = gql`
     name
     users {
       id
-      name
-      email
+      identify {
+        microsoftUserId
+      }
     }
   }
 }
@@ -2361,8 +2364,9 @@ export const AddAdminGroupUsersForClassDocument = gql`
     id
     users {
       id
-      name
-      email
+      identify {
+        microsoftUserId
+      }
     }
   }
 }
@@ -2400,8 +2404,9 @@ export const RemoveAdminGroupUsersForClassDocument = gql`
     id
     users {
       id
-      name
-      email
+      identify {
+        microsoftUserId
+      }
     }
   }
 }
@@ -4637,7 +4642,9 @@ export const GetAdminMatchDocument = gql`
       isAttending
       user {
         id
-        name
+        identify {
+          microsoftUserId
+        }
       }
       team {
         id
@@ -4941,7 +4948,9 @@ export const UpdateAdminJudgmentDocument = gql`
     name
     user {
       id
-      name
+      identify {
+        microsoftUserId
+      }
     }
     team {
       id
@@ -5108,7 +5117,9 @@ export const GetAdminCompetitionJudgeOptionsDocument = gql`
       }
       users {
         id
-        name
+        identify {
+          microsoftUserId
+        }
       }
     }
   }
@@ -5946,8 +5957,9 @@ export const GetAdminTeamsDocument = gql`
     }
     users {
       id
-      name
-      email
+      identify {
+        microsoftUserId
+      }
     }
   }
 }
@@ -5995,8 +6007,9 @@ export const GetAdminTeamDocument = gql`
     }
     users {
       id
-      name
-      email
+      identify {
+        microsoftUserId
+      }
     }
   }
 }
@@ -6150,8 +6163,9 @@ export const UpdateAdminTeamUsersDocument = gql`
     id
     users {
       id
-      name
-      email
+      identify {
+        microsoftUserId
+      }
     }
   }
 }
@@ -6227,8 +6241,6 @@ export const GetAdminUsersDocument = gql`
     query GetAdminUsers {
   users {
     id
-    name
-    email
     role
     identify {
       microsoftUserId
@@ -6288,8 +6300,6 @@ export const GetAdminUserDocument = gql`
     query GetAdminUser($id: ID!) {
   user(id: $id) {
     id
-    name
-    email
     role
     identify {
       microsoftUserId
@@ -6342,8 +6352,6 @@ export const CreateAdminUserDocument = gql`
     mutation CreateAdminUser($input: CreateUserInput!) {
   createUser(input: $input) {
     id
-    name
-    email
   }
 }
     `;
@@ -6373,42 +6381,41 @@ export function useCreateAdminUserMutation(baseOptions?: Apollo.MutationHookOpti
 export type CreateAdminUserMutationHookResult = ReturnType<typeof useCreateAdminUserMutation>;
 export type CreateAdminUserMutationResult = Apollo.MutationResult<CreateAdminUserMutation>;
 export type CreateAdminUserMutationOptions = Apollo.BaseMutationOptions<CreateAdminUserMutation, CreateAdminUserMutationVariables>;
-export const UpdateAdminUserDocument = gql`
-    mutation UpdateAdminUser($id: ID!, $input: UpdateUserInput!) {
-  updateUser(id: $id, input: $input) {
-    id
-    name
-    email
+export const BatchCreateAdminUsersDocument = gql`
+    mutation BatchCreateAdminUsers($input: BatchCreateUsersInput!) {
+  batchCreateUsers(input: $input) {
+    users {
+      id
+    }
   }
 }
     `;
-export type UpdateAdminUserMutationFn = Apollo.MutationFunction<UpdateAdminUserMutation, UpdateAdminUserMutationVariables>;
+export type BatchCreateAdminUsersMutationFn = Apollo.MutationFunction<BatchCreateAdminUsersMutation, BatchCreateAdminUsersMutationVariables>;
 
 /**
- * __useUpdateAdminUserMutation__
+ * __useBatchCreateAdminUsersMutation__
  *
- * To run a mutation, you first call `useUpdateAdminUserMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUpdateAdminUserMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useBatchCreateAdminUsersMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useBatchCreateAdminUsersMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [updateAdminUserMutation, { data, loading, error }] = useUpdateAdminUserMutation({
+ * const [batchCreateAdminUsersMutation, { data, loading, error }] = useBatchCreateAdminUsersMutation({
  *   variables: {
- *      id: // value for 'id'
  *      input: // value for 'input'
  *   },
  * });
  */
-export function useUpdateAdminUserMutation(baseOptions?: Apollo.MutationHookOptions<UpdateAdminUserMutation, UpdateAdminUserMutationVariables>) {
+export function useBatchCreateAdminUsersMutation(baseOptions?: Apollo.MutationHookOptions<BatchCreateAdminUsersMutation, BatchCreateAdminUsersMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateAdminUserMutation, UpdateAdminUserMutationVariables>(UpdateAdminUserDocument, options);
+        return Apollo.useMutation<BatchCreateAdminUsersMutation, BatchCreateAdminUsersMutationVariables>(BatchCreateAdminUsersDocument, options);
       }
-export type UpdateAdminUserMutationHookResult = ReturnType<typeof useUpdateAdminUserMutation>;
-export type UpdateAdminUserMutationResult = Apollo.MutationResult<UpdateAdminUserMutation>;
-export type UpdateAdminUserMutationOptions = Apollo.BaseMutationOptions<UpdateAdminUserMutation, UpdateAdminUserMutationVariables>;
+export type BatchCreateAdminUsersMutationHookResult = ReturnType<typeof useBatchCreateAdminUsersMutation>;
+export type BatchCreateAdminUsersMutationResult = Apollo.MutationResult<BatchCreateAdminUsersMutation>;
+export type BatchCreateAdminUsersMutationOptions = Apollo.BaseMutationOptions<BatchCreateAdminUsersMutation, BatchCreateAdminUsersMutationVariables>;
 export const DeleteAdminUserDocument = gql`
     mutation DeleteAdminUser($id: ID!) {
   deleteUser(id: $id) {
@@ -6593,8 +6600,10 @@ export const GetMeDocument = gql`
     query GetMe {
   me {
     id
-    name
     role
+    identify {
+      microsoftUserId
+    }
   }
 }
     `;

--- a/apps/admin/src/hooks/useCurrentUser.ts
+++ b/apps/admin/src/hooks/useCurrentUser.ts
@@ -6,15 +6,14 @@ export const GET_ME = gql`
   query GetMe {
     me {
       id
-      name
       role
+      identify { microsoftUserId }
     }
   }
 `
 
 type CurrentUser = {
   id: string
-  name: string
   role: Role
 }
 

--- a/apps/admin/src/lib/graphApi.ts
+++ b/apps/admin/src/lib/graphApi.ts
@@ -23,7 +23,7 @@ export async function fetchMsGraphUsers(
 
   const responses = await Promise.allSettled(
     chunks.map(async (chunk) => {
-      const filter = chunk.map((id) => `'${id}'`).join(',')
+      const filter = chunk.map((id) => `'${id.replace(/'/g, "''")}'`).join(',')
       const params = new URLSearchParams({
         $filter: `id in (${filter})`,
         $select: 'id,displayName,mail',
@@ -45,6 +45,53 @@ export async function fetchMsGraphUsers(
     if (response.status === 'fulfilled') {
       for (const user of response.value) {
         result.set(user.id, user)
+      }
+    }
+  }
+
+  return result
+}
+
+export async function fetchMsGraphUsersByEmails(
+  accessToken: string,
+  emails: string[],
+): Promise<Map<string, MsGraphUser>> {
+  const result = new Map<string, MsGraphUser>()
+  if (emails.length === 0) return result
+
+  const unique = [...new Set(emails)]
+
+  const chunks: string[][] = []
+  for (let i = 0; i < unique.length; i += CHUNK_SIZE) {
+    chunks.push(unique.slice(i, i + CHUNK_SIZE))
+  }
+
+  const responses = await Promise.allSettled(
+    chunks.map(async (chunk) => {
+      const filter = chunk.map((email) => `mail eq '${email.replace(/'/g, "''")}'`).join(' or ')
+      const params = new URLSearchParams({
+        $filter: filter,
+        $select: 'id,displayName,mail',
+      })
+      const url = `${GRAPH_BASE_URL}/users?${params.toString()}`
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      })
+      if (!res.ok) {
+        console.error(`Graph API error: ${res.status} ${res.statusText}`)
+        return []
+      }
+      const json = await res.json()
+      return (json.value ?? []) as MsGraphUser[]
+    }),
+  )
+
+  for (const response of responses) {
+    if (response.status === 'fulfilled') {
+      for (const user of response.value) {
+        if (user.mail) {
+          result.set(user.mail.toLowerCase(), user)
+        }
       }
     }
   }

--- a/apps/form/src/components/cards/AboutConfirmPage/hooks/aboutConfirm.gql.ts
+++ b/apps/form/src/components/cards/AboutConfirmPage/hooks/aboutConfirm.gql.ts
@@ -24,7 +24,7 @@ export const GET_SCENE_USERS = gql`
           team {
             users {
               id
-              name
+              identify { microsoftUserId }
             }
           }
         }
@@ -37,7 +37,7 @@ export const GET_ALL_USERS = gql`
   query GetAllUsers {
     users {
       id
-      name
+      identify { microsoftUserId }
     }
   }
 `;

--- a/apps/form/src/features/hooks/useTeamEdit.ts
+++ b/apps/form/src/features/hooks/useTeamEdit.ts
@@ -19,6 +19,7 @@ import {
   GetSportsceneEntriesDocument,
   GetTeamDocument,
 } from "@/gql/__generated__/graphql";
+import { useMsGraphUsers } from "@/hooks/useMsGraphUsers";
 
 export type StudentInformation = {
   studentId: string;
@@ -55,6 +56,25 @@ export function useTeamEdit() {
     variables: { sportId: sports },
   });
 
+  // Graph API でユーザー名を解決
+  const userMsIds = useMemo(
+    () => [
+      ...(userData?.users ?? []).map((u) => u.identify?.microsoftUserId).filter((id): id is string => !!id),
+      ...(teamData?.team?.users ?? []).map((u) => u.identify?.microsoftUserId).filter((id): id is string => !!id),
+    ],
+    [userData, teamData],
+  );
+  const { msGraphUsers, loading: msGraphLoading } = useMsGraphUsers(userMsIds);
+
+  const resolveName = useCallback(
+    (user: { identify?: { microsoftUserId?: string | null } | null }) => {
+      const msId = user.identify?.microsoftUserId;
+      const msUser = msId ? msGraphUsers.get(msId) : undefined;
+      return msUser?.displayName ?? '';
+    },
+    [msGraphUsers],
+  );
+
   const experiencedLimit = experienceData?.sport?.experiencedLimit ?? null;
 
   // 既存の経験者データで初期化（一度だけ）
@@ -82,6 +102,7 @@ export function useTeamEdit() {
     sportSceneLoading ||
     sportSceneEntriesLoading ||
     experienceLoading ||
+    msGraphLoading ||
     (hasTeamId && teamLoading);
 
   const groupId = meData?.me?.groups?.[0]?.id ?? "";
@@ -90,10 +111,10 @@ export function useTeamEdit() {
     return (
       teamData?.team?.users?.map((u) => ({
         studentId: u.id,
-        studentName: u.name,
+        studentName: resolveName(u),
       })) ?? []
     );
-  }, [teamData?.team?.users]);
+  }, [teamData?.team?.users, resolveName]);
 
   const selectedMember = useMemo(
     () => localSelectedMember ?? teamMembersFromQuery,
@@ -115,9 +136,10 @@ export function useTeamEdit() {
     if (!userData?.users) return [];
     return userData.users.filter((u) => {
       if (searchName === "") return true;
-      return u.name.includes(searchName);
+      const displayName = resolveName(u);
+      return displayName.includes(searchName);
     });
-  }, [userData?.users, searchName]);
+  }, [userData?.users, searchName, resolveName]);
 
   const myTeamUserIds = useMemo(() => {
     return teamMembersFromQuery.map((u) => u.studentId);

--- a/apps/form/src/features/scenes.gql.ts
+++ b/apps/form/src/features/scenes.gql.ts
@@ -72,7 +72,7 @@ export const GET_TEAM_DATA = gql`
         entries {
           team {
             users {
-              name
+              identify { microsoftUserId }
             }
           }
         }
@@ -93,7 +93,7 @@ export const GET_SCENE_SPORT = gql`
             name
             users {
               id
-              name
+              identify { microsoftUserId }
             }
           }
         }
@@ -127,7 +127,7 @@ export const GET_ALLTEAMDATA = gql`
             name
             users {
               id
-              name
+              identify { microsoftUserId }
             }
           }
         }

--- a/apps/form/src/features/teamEdit.gql.ts
+++ b/apps/form/src/features/teamEdit.gql.ts
@@ -15,7 +15,7 @@ export const GET_USERS = gql`
   query GetUsers {
     users {
       id
-      name
+      identify { microsoftUserId }
     }
   }
 `;
@@ -69,7 +69,7 @@ export const GET_TEAM = gql`
     team(id: $teamId) {
       users {
         id
-        name
+        identify { microsoftUserId }
       }
     }
   }

--- a/apps/form/src/gql/__generated__/graphql.ts
+++ b/apps/form/src/gql/__generated__/graphql.ts
@@ -38,6 +38,16 @@ export type AssignSeedTeamInput = {
   teamId?: InputMaybe<Scalars['ID']['input']>;
 };
 
+/** CSVインポート等でユーザーを一括作成するための入力 */
+export type BatchCreateUsersInput = {
+  users: Array<CreateUserInput>;
+};
+
+export type BatchCreateUsersResult = {
+  __typename?: 'BatchCreateUsersResult';
+  users: Array<User>;
+};
+
 export enum BracketState {
   Building = 'BUILDING',
   Completed = 'COMPLETED',
@@ -164,8 +174,8 @@ export type CreateTournamentMatchInput = {
 };
 
 export type CreateUserInput = {
-  email: Scalars['String']['input'];
-  name: Scalars['String']['input'];
+  groupId?: InputMaybe<Scalars['ID']['input']>;
+  microsoftUserId: Scalars['String']['input'];
 };
 
 export type DeleteSportEntriesInput = {
@@ -325,6 +335,8 @@ export type Mutation = {
   applyCompetitionDefaults: Array<Match>;
   /** SEEDスロットへのチーム手動配置（teamId=null でクリア） */
   assignSeedTeam: TournamentSlot;
+  /** ユーザーを一括作成する（CSV インポート用） */
+  batchCreateUsers: BatchCreateUsersResult;
   /** 大会を作成する */
   createCompetition: Competition;
   createGroup: Group;
@@ -445,7 +457,6 @@ export type Mutation = {
   updateTeamUsers: Team;
   /** トーナメント（ブラケット）を更新する */
   updateTournament: Tournament;
-  updateUser: User;
   /** ユーザーのロールを更新する（user:manage パーミッションが必要） */
   updateUserRole: User;
 };
@@ -495,6 +506,11 @@ export type MutationApplyCompetitionDefaultsArgs = {
 
 export type MutationAssignSeedTeamArgs = {
   input: AssignSeedTeamInput;
+};
+
+
+export type MutationBatchCreateUsersArgs = {
+  input: BatchCreateUsersInput;
 };
 
 
@@ -881,12 +897,6 @@ export type MutationUpdateTeamUsersArgs = {
 export type MutationUpdateTournamentArgs = {
   id: Scalars['ID']['input'];
   input: UpdateTournamentInput;
-};
-
-
-export type MutationUpdateUserArgs = {
-  id: Scalars['ID']['input'];
-  input: UpdateUserInput;
 };
 
 
@@ -1363,19 +1373,12 @@ export type UpdateTournamentInput = {
   name?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type UpdateUserInput = {
-  email?: InputMaybe<Scalars['String']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-};
-
 export type User = {
   __typename?: 'User';
-  email: Scalars['String']['output'];
   groups: Array<Group>;
   id: Scalars['ID']['output'];
   identify: UserIdentify;
   judgments: Array<Judgment>;
-  name: Scalars['String']['output'];
   role: Role;
   teams: Array<Team>;
 };
@@ -1383,7 +1386,7 @@ export type User = {
 export type UserIdentify = {
   __typename?: 'UserIdentify';
   microsoftUserId?: Maybe<Scalars['String']['output']>;
-  sub: Scalars['ID']['output'];
+  sub?: Maybe<Scalars['ID']['output']>;
 };
 
 export type GetSceneIdQueryVariables = Exact<{ [key: string]: never; }>;
@@ -1394,12 +1397,12 @@ export type GetSceneIdQuery = { __typename?: 'Query', scenes: Array<{ __typename
 export type GetSceneUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetSceneUsersQuery = { __typename?: 'Query', scenes: Array<{ __typename?: 'Scene', isDeleted: boolean, sportScenes: Array<{ __typename?: 'SportScene', scene: { __typename?: 'Scene', id: string }, entries: Array<{ __typename?: 'SportEntry', team: { __typename?: 'Team', users: Array<{ __typename?: 'User', id: string, name: string }> } }> }> }> };
+export type GetSceneUsersQuery = { __typename?: 'Query', scenes: Array<{ __typename?: 'Scene', isDeleted: boolean, sportScenes: Array<{ __typename?: 'SportScene', scene: { __typename?: 'Scene', id: string }, entries: Array<{ __typename?: 'SportEntry', team: { __typename?: 'Team', users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } }> }> }> };
 
 export type GetAllUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAllUsersQuery = { __typename?: 'Query', users: Array<{ __typename?: 'User', id: string, name: string }> };
+export type GetAllUsersQuery = { __typename?: 'Query', users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> };
 
 export type GetTypeQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1437,17 +1440,17 @@ export type SportDataGetQuery = { __typename?: 'Query', sport: { __typename?: 'S
 export type GetTeamDataQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetTeamDataQuery = { __typename?: 'Query', scenes: Array<{ __typename?: 'Scene', isDeleted: boolean, sportScenes: Array<{ __typename?: 'SportScene', sport: { __typename?: 'Sport', id: string }, scene: { __typename?: 'Scene', id: string }, entries: Array<{ __typename?: 'SportEntry', team: { __typename?: 'Team', users: Array<{ __typename?: 'User', name: string }> } }> }> }> };
+export type GetTeamDataQuery = { __typename?: 'Query', scenes: Array<{ __typename?: 'Scene', isDeleted: boolean, sportScenes: Array<{ __typename?: 'SportScene', sport: { __typename?: 'Sport', id: string }, scene: { __typename?: 'Scene', id: string }, entries: Array<{ __typename?: 'SportEntry', team: { __typename?: 'Team', users: Array<{ __typename?: 'User', identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } }> }> }> };
 
 export type GetSceneSportQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetSceneSportQuery = { __typename?: 'Query', scenes: Array<{ __typename?: 'Scene', isDeleted: boolean, sportScenes: Array<{ __typename?: 'SportScene', id: string, entries: Array<{ __typename?: 'SportEntry', team: { __typename?: 'Team', id: string, name: string, users: Array<{ __typename?: 'User', id: string, name: string }> } }>, sport: { __typename?: 'Sport', id: string }, scene: { __typename?: 'Scene', id: string } }> }> };
+export type GetSceneSportQuery = { __typename?: 'Query', scenes: Array<{ __typename?: 'Scene', isDeleted: boolean, sportScenes: Array<{ __typename?: 'SportScene', id: string, entries: Array<{ __typename?: 'SportEntry', team: { __typename?: 'Team', id: string, name: string, users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } }>, sport: { __typename?: 'Sport', id: string }, scene: { __typename?: 'Scene', id: string } }> }> };
 
 export type GetAllTeamdataQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAllTeamdataQuery = { __typename?: 'Query', scenes: Array<{ __typename?: 'Scene', isDeleted: boolean, sportScenes: Array<{ __typename?: 'SportScene', scene: { __typename?: 'Scene', id: string, name: string }, sport: { __typename?: 'Sport', id: string, name: string }, entries: Array<{ __typename?: 'SportEntry', team: { __typename?: 'Team', id: string, name: string, users: Array<{ __typename?: 'User', id: string, name: string }> } }> }> }> };
+export type GetAllTeamdataQuery = { __typename?: 'Query', scenes: Array<{ __typename?: 'Scene', isDeleted: boolean, sportScenes: Array<{ __typename?: 'SportScene', scene: { __typename?: 'Scene', id: string, name: string }, sport: { __typename?: 'Sport', id: string, name: string }, entries: Array<{ __typename?: 'SportEntry', team: { __typename?: 'Team', id: string, name: string, users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } }> }> }> };
 
 export type GetAllSportExperiencesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1469,7 +1472,7 @@ export type GetMeQuery = { __typename?: 'Query', me: { __typename?: 'User', id: 
 export type GetUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetUsersQuery = { __typename?: 'Query', users: Array<{ __typename?: 'User', id: string, name: string }> };
+export type GetUsersQuery = { __typename?: 'Query', users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> };
 
 export type GetSportsceneQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1486,7 +1489,7 @@ export type GetTeamQueryVariables = Exact<{
 }>;
 
 
-export type GetTeamQuery = { __typename?: 'Query', team: { __typename?: 'Team', users: Array<{ __typename?: 'User', id: string, name: string }> } };
+export type GetTeamQuery = { __typename?: 'Query', team: { __typename?: 'Team', users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } };
 
 export type CreateTeamMutationVariables = Exact<{
   input: CreateTeamInput;
@@ -1603,7 +1606,9 @@ export const GetSceneUsersDocument = gql`
         team {
           users {
             id
-            name
+            identify {
+              microsoftUserId
+            }
           }
         }
       }
@@ -1647,7 +1652,9 @@ export const GetAllUsersDocument = gql`
     query GetAllUsers {
   users {
     id
-    name
+    identify {
+      microsoftUserId
+    }
   }
 }
     `;
@@ -1915,7 +1922,9 @@ export const GetTeamDataDocument = gql`
       entries {
         team {
           users {
-            name
+            identify {
+              microsoftUserId
+            }
           }
         }
       }
@@ -1967,7 +1976,9 @@ export const GetSceneSportDocument = gql`
           name
           users {
             id
-            name
+            identify {
+              microsoftUserId
+            }
           }
         }
       }
@@ -2032,7 +2043,9 @@ export const GetAllTeamdataDocument = gql`
           name
           users {
             id
-            name
+            identify {
+              microsoftUserId
+            }
           }
         }
       }
@@ -2191,7 +2204,9 @@ export const GetUsersDocument = gql`
     query GetUsers {
   users {
     id
-    name
+    identify {
+      microsoftUserId
+    }
   }
 }
     `;
@@ -2338,7 +2353,9 @@ export const GetTeamDocument = gql`
   team(id: $teamId) {
     users {
       id
-      name
+      identify {
+        microsoftUserId
+      }
     }
   }
 }

--- a/apps/form/src/hooks/useMsGraphUsers.ts
+++ b/apps/form/src/hooks/useMsGraphUsers.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react'
+import { userManager } from '@/lib/userManager'
+import { fetchMsGraphUsers } from '@/lib/graphApi'
+import type { MsGraphUser } from '@/lib/graphApi'
+
+export function useMsGraphUsers(microsoftUserIds: string[]) {
+  const [msGraphUsers, setMsGraphUsers] = useState<Map<string, MsGraphUser>>(
+    new Map(),
+  )
+  const [loading, setLoading] = useState(false)
+  const cacheRef = useRef<Map<string, MsGraphUser>>(new Map())
+
+  const filtered = microsoftUserIds.filter(Boolean)
+  const sortedKey = [...new Set(filtered)].sort().join(',')
+
+  useEffect(() => {
+    if (!sortedKey) {
+      setMsGraphUsers(new Map())
+      return
+    }
+
+    const ids = sortedKey.split(',')
+    const uncachedIds = ids.filter((id) => !cacheRef.current.has(id))
+
+    if (uncachedIds.length === 0) {
+      const cached = new Map<string, MsGraphUser>()
+      for (const id of ids) {
+        const u = cacheRef.current.get(id)
+        if (u) cached.set(id, u)
+      }
+      setMsGraphUsers(cached)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+
+    ;(async () => {
+      try {
+        const user = await userManager.getUser()
+        if (!user?.access_token || cancelled) return
+
+        const fetched = await fetchMsGraphUsers(user.access_token, uncachedIds)
+        if (cancelled) return
+
+        for (const [id, u] of fetched) {
+          cacheRef.current.set(id, u)
+        }
+
+        const merged = new Map<string, MsGraphUser>()
+        for (const id of ids) {
+          const u = cacheRef.current.get(id)
+          if (u) merged.set(id, u)
+        }
+        setMsGraphUsers(merged)
+      } catch (e) {
+        console.error('Failed to fetch MS Graph users:', e)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [sortedKey])
+
+  return { msGraphUsers, loading }
+}

--- a/apps/form/src/lib/graphApi.ts
+++ b/apps/form/src/lib/graphApi.ts
@@ -1,0 +1,53 @@
+const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0'
+const CHUNK_SIZE = 15
+
+export type MsGraphUser = {
+  id: string
+  displayName: string
+  mail: string | null
+}
+
+export async function fetchMsGraphUsers(
+  accessToken: string,
+  microsoftUserIds: string[],
+): Promise<Map<string, MsGraphUser>> {
+  const result = new Map<string, MsGraphUser>()
+  if (microsoftUserIds.length === 0) return result
+
+  const unique = [...new Set(microsoftUserIds)]
+
+  const chunks: string[][] = []
+  for (let i = 0; i < unique.length; i += CHUNK_SIZE) {
+    chunks.push(unique.slice(i, i + CHUNK_SIZE))
+  }
+
+  const responses = await Promise.allSettled(
+    chunks.map(async (chunk) => {
+      const filter = chunk.map((id) => `'${id.replace(/'/g, "''")}'`).join(',')
+      const params = new URLSearchParams({
+        $filter: `id in (${filter})`,
+        $select: 'id,displayName,mail',
+      })
+      const url = `${GRAPH_BASE_URL}/users?${params.toString()}`
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      })
+      if (!res.ok) {
+        console.error(`Graph API error: ${res.status} ${res.statusText}`)
+        return []
+      }
+      const json = await res.json()
+      return (json.value ?? []) as MsGraphUser[]
+    }),
+  )
+
+  for (const response of responses) {
+    if (response.status === 'fulfilled') {
+      for (const user of response.value) {
+        result.set(user.id, user)
+      }
+    }
+  }
+
+  return result
+}

--- a/apps/panel/app/(authenticated)/discover/page.tsx
+++ b/apps/panel/app/(authenticated)/discover/page.tsx
@@ -74,8 +74,8 @@ export default function DiscoverPage() {
     const [searchText, setSearchText] = React.useState("");
     const filteredUsers = searchText
         ? users.filter(user =>
-            user.name.toLowerCase().includes(searchText.toLowerCase()) ||
-            user.email.toLowerCase().includes(searchText.toLowerCase())
+            (user.name ?? '').toLowerCase().includes(searchText.toLowerCase()) ||
+            (user.email ?? '').toLowerCase().includes(searchText.toLowerCase())
         )
         : [];
 

--- a/apps/panel/components/context/index.tsx
+++ b/apps/panel/components/context/index.tsx
@@ -1,14 +1,14 @@
 import {createContext} from "react";
 import type {
-    GetPanelUsersQuery,
     GetPanelTeamsQuery,
     GetPanelCompetitionsQuery,
     GetPanelMatchesQuery,
     GetPanelLocationsQuery,
     GetPanelImagesQuery,
 } from "@/src/gql/__generated__/graphql";
+import type { ResolvedUser } from "@/src/features/users/hook";
 
-type PanelUser = GetPanelUsersQuery["users"][number];
+type PanelUser = ResolvedUser;
 type PanelTeam = GetPanelTeamsQuery["teams"][number];
 type PanelCompetition = GetPanelCompetitionsQuery["competitions"][number];
 type PanelMatch = GetPanelMatchesQuery["matches"][number];

--- a/apps/panel/components/dashboard/Overview/index.tsx
+++ b/apps/panel/components/dashboard/Overview/index.tsx
@@ -25,13 +25,11 @@ import {TournamentRankList} from "@/components/game/RankList/TournamentRankList"
 type PanelSport = GetPanelSportsQuery["sports"][number];
 type PanelTeam = GetPanelTeamsQuery["teams"][number];
 type PanelCompetition = GetPanelCompetitionsQuery["competitions"][number];
-type TeamUser = PanelTeam["users"][number];
-
 export type OverviewProps = {
     mySport: PanelSport;
     myGame: PanelCompetition;
     myTeam: PanelTeam;
-    myTeamUsers: TeamUser[];
+    myTeamUsers: Array<{ id: string; name: string }>;
     myTeamRank: number;
 }
 

--- a/apps/panel/components/discover/DiscoverTeamContent.tsx
+++ b/apps/panel/components/discover/DiscoverTeamContent.tsx
@@ -15,10 +15,11 @@ import {HiXMark, HiClock} from "react-icons/hi2";
 import {Fragment} from "react";
 import * as React from "react";
 
-import type { GetPanelImagesQuery, GetPanelLocationsQuery, GetPanelUsersQuery } from "@/src/gql/__generated__/graphql"
+import type { GetPanelImagesQuery, GetPanelLocationsQuery } from "@/src/gql/__generated__/graphql"
+import type { ResolvedUser } from "@/src/features/users/hook"
 import {MatchSet} from "@/src/features/unit/discover";
 
-type PanelUser = GetPanelUsersQuery["users"][number];
+type PanelUser = ResolvedUser;
 type PanelImage = GetPanelImagesQuery["images"][number];
 type PanelLocation = GetPanelLocationsQuery["locations"][number];
 

--- a/apps/panel/components/discover/discoverUser.tsx
+++ b/apps/panel/components/discover/discoverUser.tsx
@@ -9,11 +9,12 @@ import {
 } from "@mui/material";
 import * as React from "react";
 import {HiOutlineExclamationTriangle, HiUser} from "react-icons/hi2";
-import type { GetPanelUsersQuery, GetPanelCompetitionsQuery, GetPanelTeamsQuery, GetPanelMatchesQuery } from "@/src/gql/__generated__/graphql";
+import type { GetPanelCompetitionsQuery, GetPanelTeamsQuery, GetPanelMatchesQuery } from "@/src/gql/__generated__/graphql";
+import type { ResolvedUser } from "@/src/features/users/hook";
 import {UserMatchList} from "@/components/match/userMatchList";
 import {useFetchSports} from "@/src/features/sports/hook";
 
-type PanelUser = GetPanelUsersQuery["users"][number];
+type PanelUser = ResolvedUser;
 type PanelCompetition = GetPanelCompetitionsQuery["competitions"][number];
 type PanelTeam = GetPanelTeamsQuery["teams"][number];
 type PanelMatch = GetPanelMatchesQuery["matches"][number];

--- a/apps/panel/src/features/classes/api.ts
+++ b/apps/panel/src/features/classes/api.ts
@@ -17,8 +17,7 @@ export const GET_GROUP = gql`
       name
       users {
         id
-        name
-        email
+        identify { microsoftUserId }
       }
       teams {
         id

--- a/apps/panel/src/features/matches/api.ts
+++ b/apps/panel/src/features/matches/api.ts
@@ -116,7 +116,6 @@ export const GET_MATCH = gql`
         isAttending
         user {
           id
-          name
         }
         team {
           id

--- a/apps/panel/src/features/teams/api.ts
+++ b/apps/panel/src/features/teams/api.ts
@@ -11,7 +11,7 @@ export const GET_TEAMS = gql`
       }
       users {
         id
-        name
+        identify { microsoftUserId }
       }
     }
   }
@@ -28,8 +28,7 @@ export const GET_TEAM = gql`
       }
       users {
         id
-        name
-        email
+        identify { microsoftUserId }
       }
     }
   }

--- a/apps/panel/src/features/unit/dashboard/index.ts
+++ b/apps/panel/src/features/unit/dashboard/index.ts
@@ -4,7 +4,7 @@ import { useFetchTeams } from "@/src/features/teams/hook";
 import { useFetchSports } from "@/src/features/sports/hook";
 import { useFetchGames } from "@/src/features/games/hook";
 import { useFetchMatches } from "@/src/features/matches/hook";
-import { useFetchUsers } from "@/src/features/users/hook";
+import { useFetchUsers, type ResolvedUser } from "@/src/features/users/hook";
 import { useFetchImages } from "@/src/features/images/hook";
 import { useFetchUserinfo } from "@/src/features/userinfo/hook";
 import {
@@ -27,7 +27,7 @@ type GqlTeam = GetPanelTeamsQuery["teams"][0];
 type GqlMatch = GetPanelMatchesQuery["matches"][0];
 type GqlLocation = GetPanelLocationsQuery["locations"][0];
 type GqlImage = GetPanelImagesQuery["images"][0];
-type GqlUser = GetPanelUsersQuery["users"][0];
+type GqlUser = ResolvedUser;
 type GqlCompetition = GetPanelCompetitionsQuery["competitions"][0];
 type GqlMeUser = GetPanelMeQuery["me"];
 
@@ -43,7 +43,7 @@ export type DashboardDataType = {
   mySport: GqlSport | undefined;
   myGame: GqlCompetition | undefined;
   myTeam: GqlTeam | undefined;
-  myTeamUsers: GqlTeam["users"];
+  myTeamUsers: Array<{ id: string; name: string }>;
   myTeamMatches: GqlMatch[];
   myTeamRank: number;
   myJudgeMatches: GqlMatch[];
@@ -66,7 +66,7 @@ export const useFetchDashboard = () => {
   const [myGameState, setMyGame] = useState<GqlCompetition | undefined>(undefined);
   const [myTeamState, setMyTeam] = useState<GqlTeam | undefined>(undefined);
   const [myTeamMatchesState, setMyTeamMatches] = useState<GqlMatch[]>([]);
-  const [myTeamUsersState, setMyTeamUsers] = useState<GqlTeam["users"]>([]);
+  const [myTeamUsersState, setMyTeamUsers] = useState<Array<{ id: string; name: string }>>([]);
   const [myTeamRankState, setMyTeamRank] = useState<number>(0);
   const [myJudgeMatchesState, setMyJudgeMatches] = useState<GqlMatch[]>([]);
 
@@ -109,7 +109,10 @@ export const useFetchDashboard = () => {
 
           if (myTeam) {
             setMyTeam(myTeam);
-            setMyTeamUsers(myTeam.users);
+            setMyTeamUsers(myTeam.users.map(u => {
+              const resolved = users.find(ru => ru.id === u.id);
+              return { id: u.id, name: resolved?.name ?? '' };
+            }));
 
             const mySport = sports.find((s) => s.id === myCompetition.sport?.id);
             if (mySport) setMySport(mySport);

--- a/apps/panel/src/features/unit/discover/index.ts
+++ b/apps/panel/src/features/unit/discover/index.ts
@@ -1,4 +1,4 @@
-import { useFetchUsers } from "@/src/features/users/hook";
+import { useFetchUsers, type ResolvedUser } from "@/src/features/users/hook";
 import { useFetchTeams } from "@/src/features/teams/hook";
 import { useFetchSports } from "@/src/features/sports/hook";
 import { useFetchMatches } from "@/src/features/matches/hook";
@@ -16,7 +16,7 @@ import {
 // GraphQL 生成型エイリアス
 type GqlMatch = GetPanelMatchesQuery["matches"][0];
 type GqlTeam = GetPanelTeamsQuery["teams"][0];
-type GqlUser = GetPanelUsersQuery["users"][0];
+type GqlUser = ResolvedUser;
 type GqlSport = GetPanelSportsQuery["sports"][0];
 type GqlGroup = GetPanelMeQuery["me"]["groups"][0]; // class = group の同義語
 

--- a/apps/panel/src/features/userinfo/api.ts
+++ b/apps/panel/src/features/userinfo/api.ts
@@ -4,8 +4,7 @@ export const GET_ME = gql`
   query GetPanelMe {
     me {
       id
-      name
-      email
+      identify { microsoftUserId }
       groups {
         id
         name

--- a/apps/panel/src/features/userinfo/hook/index.ts
+++ b/apps/panel/src/features/userinfo/hook/index.ts
@@ -1,9 +1,27 @@
+import { useMemo } from "react";
 import { useGetPanelMeQuery } from "@/src/gql/__generated__/graphql";
+import { useMsGraphUsers } from "@/src/hooks/useMsGraphUsers";
 
 export const useFetchUserinfo = () => {
   const { data, loading } = useGetPanelMeQuery();
+  const msIds = useMemo(
+    () => [data?.me?.identify?.microsoftUserId].filter((id): id is string => !!id),
+    [data],
+  );
+  const { msGraphUsers, loading: msGraphLoading } = useMsGraphUsers(msIds);
+
+  const user = useMemo(() => {
+    if (!data?.me) return undefined;
+    const msId = data.me.identify?.microsoftUserId;
+    const msUser = msId ? msGraphUsers.get(msId) : undefined;
+    return {
+      ...data.me,
+      name: msUser?.displayName ?? '',
+    };
+  }, [data, msGraphUsers]);
+
   return {
-    user: data?.me,
-    isFetching: loading,
+    user,
+    isFetching: loading || msGraphLoading,
   };
 };

--- a/apps/panel/src/features/users/api.ts
+++ b/apps/panel/src/features/users/api.ts
@@ -4,8 +4,7 @@ export const GET_USERS = gql`
   query GetPanelUsers {
     users {
       id
-      name
-      email
+      identify { microsoftUserId }
       teams {
         id
         name
@@ -18,8 +17,7 @@ export const GET_USER = gql`
   query GetPanelUser($id: ID!) {
     user(id: $id) {
       id
-      name
-      email
+      identify { microsoftUserId }
       groups {
         id
         name

--- a/apps/panel/src/features/users/hook/index.ts
+++ b/apps/panel/src/features/users/hook/index.ts
@@ -1,13 +1,43 @@
+import { useMemo } from "react";
 import {
   useGetPanelUsersQuery,
   useGetPanelUserQuery,
 } from "@/src/gql/__generated__/graphql";
+import { useMsGraphUsers } from "@/src/hooks/useMsGraphUsers";
+
+export type ResolvedUser = ReturnType<typeof useFetchUsers>["users"][number];
 
 export const useFetchUsers = () => {
   const { data, loading, refetch } = useGetPanelUsersQuery();
+
+  const microsoftUserIds = useMemo(
+    () =>
+      (data?.users ?? [])
+        .map((u) => u.identify?.microsoftUserId)
+        .filter((id): id is string => !!id),
+    [data],
+  );
+
+  const { msGraphUsers, loading: msGraphLoading } =
+    useMsGraphUsers(microsoftUserIds);
+
+  const users = useMemo(
+    () =>
+      (data?.users ?? []).map((u) => {
+        const msId = u.identify?.microsoftUserId;
+        const msUser = msId ? msGraphUsers.get(msId) : undefined;
+        return {
+          ...u,
+          name: msUser?.displayName ?? '',
+          email: msUser?.mail ?? '',
+        };
+      }),
+    [data, msGraphUsers],
+  );
+
   return {
-    users: data?.users ?? [],
-    isFetching: loading,
+    users,
+    isFetching: loading || msGraphLoading,
     refresh: refetch,
   };
 };

--- a/apps/panel/src/gql/__generated__/graphql.ts
+++ b/apps/panel/src/gql/__generated__/graphql.ts
@@ -38,6 +38,16 @@ export type AssignSeedTeamInput = {
   teamId?: InputMaybe<Scalars['ID']['input']>;
 };
 
+/** CSVインポート等でユーザーを一括作成するための入力 */
+export type BatchCreateUsersInput = {
+  users: Array<CreateUserInput>;
+};
+
+export type BatchCreateUsersResult = {
+  __typename?: 'BatchCreateUsersResult';
+  users: Array<User>;
+};
+
 export enum BracketState {
   Building = 'BUILDING',
   Completed = 'COMPLETED',
@@ -164,8 +174,8 @@ export type CreateTournamentMatchInput = {
 };
 
 export type CreateUserInput = {
-  email: Scalars['String']['input'];
-  name: Scalars['String']['input'];
+  groupId?: InputMaybe<Scalars['ID']['input']>;
+  microsoftUserId: Scalars['String']['input'];
 };
 
 export type DeleteSportEntriesInput = {
@@ -325,6 +335,8 @@ export type Mutation = {
   applyCompetitionDefaults: Array<Match>;
   /** SEEDスロットへのチーム手動配置（teamId=null でクリア） */
   assignSeedTeam: TournamentSlot;
+  /** ユーザーを一括作成する（CSV インポート用） */
+  batchCreateUsers: BatchCreateUsersResult;
   /** 大会を作成する */
   createCompetition: Competition;
   createGroup: Group;
@@ -445,7 +457,6 @@ export type Mutation = {
   updateTeamUsers: Team;
   /** トーナメント（ブラケット）を更新する */
   updateTournament: Tournament;
-  updateUser: User;
   /** ユーザーのロールを更新する（user:manage パーミッションが必要） */
   updateUserRole: User;
 };
@@ -495,6 +506,11 @@ export type MutationApplyCompetitionDefaultsArgs = {
 
 export type MutationAssignSeedTeamArgs = {
   input: AssignSeedTeamInput;
+};
+
+
+export type MutationBatchCreateUsersArgs = {
+  input: BatchCreateUsersInput;
 };
 
 
@@ -881,12 +897,6 @@ export type MutationUpdateTeamUsersArgs = {
 export type MutationUpdateTournamentArgs = {
   id: Scalars['ID']['input'];
   input: UpdateTournamentInput;
-};
-
-
-export type MutationUpdateUserArgs = {
-  id: Scalars['ID']['input'];
-  input: UpdateUserInput;
 };
 
 
@@ -1363,19 +1373,12 @@ export type UpdateTournamentInput = {
   name?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type UpdateUserInput = {
-  email?: InputMaybe<Scalars['String']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-};
-
 export type User = {
   __typename?: 'User';
-  email: Scalars['String']['output'];
   groups: Array<Group>;
   id: Scalars['ID']['output'];
   identify: UserIdentify;
   judgments: Array<Judgment>;
-  name: Scalars['String']['output'];
   role: Role;
   teams: Array<Team>;
 };
@@ -1383,7 +1386,7 @@ export type User = {
 export type UserIdentify = {
   __typename?: 'UserIdentify';
   microsoftUserId?: Maybe<Scalars['String']['output']>;
-  sub: Scalars['ID']['output'];
+  sub?: Maybe<Scalars['ID']['output']>;
 };
 
 export type GetPanelGroupsQueryVariables = Exact<{ [key: string]: never; }>;
@@ -1396,7 +1399,7 @@ export type GetPanelGroupQueryVariables = Exact<{
 }>;
 
 
-export type GetPanelGroupQuery = { __typename?: 'Query', group: { __typename?: 'Group', id: string, name: string, users: Array<{ __typename?: 'User', id: string, name: string, email: string }>, teams: Array<{ __typename?: 'Team', id: string, name: string }> } };
+export type GetPanelGroupQuery = { __typename?: 'Query', group: { __typename?: 'Group', id: string, name: string, users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }>, teams: Array<{ __typename?: 'Team', id: string, name: string }> } };
 
 export type GetPanelCompetitionsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1478,7 +1481,7 @@ export type GetPanelMatchQueryVariables = Exact<{
 }>;
 
 
-export type GetPanelMatchQuery = { __typename?: 'Query', match: { __typename?: 'Match', id: string, time: string, status: MatchStatus, location?: { __typename?: 'Location', id: string, name: string } | null, competition: { __typename?: 'Competition', id: string, name: string, scene: { __typename?: 'Scene', id: string } }, winnerTeam?: { __typename?: 'Team', id: string, name: string } | null, entries: Array<{ __typename?: 'MatchEntry', id: string, score: number, team?: { __typename?: 'Team', id: string, name: string } | null }>, judgment?: { __typename?: 'Judgment', id: string, name?: string | null, isAttending: boolean, user?: { __typename?: 'User', id: string, name: string } | null, team?: { __typename?: 'Team', id: string, name: string } | null, group?: { __typename?: 'Group', id: string } | null } | null } };
+export type GetPanelMatchQuery = { __typename?: 'Query', match: { __typename?: 'Match', id: string, time: string, status: MatchStatus, location?: { __typename?: 'Location', id: string, name: string } | null, competition: { __typename?: 'Competition', id: string, name: string, scene: { __typename?: 'Scene', id: string } }, winnerTeam?: { __typename?: 'Team', id: string, name: string } | null, entries: Array<{ __typename?: 'MatchEntry', id: string, score: number, team?: { __typename?: 'Team', id: string, name: string } | null }>, judgment?: { __typename?: 'Judgment', id: string, name?: string | null, isAttending: boolean, user?: { __typename?: 'User', id: string } | null, team?: { __typename?: 'Team', id: string, name: string } | null, group?: { __typename?: 'Group', id: string } | null } | null } };
 
 export type GetPanelSportsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1507,31 +1510,31 @@ export type GetPanelSceneQuery = { __typename?: 'Query', scene: { __typename?: '
 export type GetPanelTeamsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetPanelTeamsQuery = { __typename?: 'Query', teams: Array<{ __typename?: 'Team', id: string, name: string, group: { __typename?: 'Group', id: string, name: string }, users: Array<{ __typename?: 'User', id: string, name: string }> }> };
+export type GetPanelTeamsQuery = { __typename?: 'Query', teams: Array<{ __typename?: 'Team', id: string, name: string, group: { __typename?: 'Group', id: string, name: string }, users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> }> };
 
 export type GetPanelTeamQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetPanelTeamQuery = { __typename?: 'Query', team: { __typename?: 'Team', id: string, name: string, group: { __typename?: 'Group', id: string, name: string }, users: Array<{ __typename?: 'User', id: string, name: string, email: string }> } };
+export type GetPanelTeamQuery = { __typename?: 'Query', team: { __typename?: 'Team', id: string, name: string, group: { __typename?: 'Group', id: string, name: string }, users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } };
 
 export type GetPanelMeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetPanelMeQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string, name: string, email: string, groups: Array<{ __typename?: 'Group', id: string, name: string }>, teams: Array<{ __typename?: 'Team', id: string, name: string }> } };
+export type GetPanelMeQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null }, groups: Array<{ __typename?: 'Group', id: string, name: string }>, teams: Array<{ __typename?: 'Team', id: string, name: string }> } };
 
 export type GetPanelUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetPanelUsersQuery = { __typename?: 'Query', users: Array<{ __typename?: 'User', id: string, name: string, email: string, teams: Array<{ __typename?: 'Team', id: string, name: string }> }> };
+export type GetPanelUsersQuery = { __typename?: 'Query', users: Array<{ __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null }, teams: Array<{ __typename?: 'Team', id: string, name: string }> }> };
 
 export type GetPanelUserQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type GetPanelUserQuery = { __typename?: 'Query', user: { __typename?: 'User', id: string, name: string, email: string, groups: Array<{ __typename?: 'Group', id: string, name: string }>, teams: Array<{ __typename?: 'Team', id: string, name: string }> } };
+export type GetPanelUserQuery = { __typename?: 'Query', user: { __typename?: 'User', id: string, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null }, groups: Array<{ __typename?: 'Group', id: string, name: string }>, teams: Array<{ __typename?: 'Team', id: string, name: string }> } };
 
 
 export const GetPanelGroupsDocument = gql`
@@ -1581,8 +1584,9 @@ export const GetPanelGroupDocument = gql`
     name
     users {
       id
-      name
-      email
+      identify {
+        microsoftUserId
+      }
     }
     teams {
       id
@@ -2220,7 +2224,6 @@ export const GetPanelMatchDocument = gql`
       isAttending
       user {
         id
-        name
       }
       team {
         id
@@ -2477,7 +2480,9 @@ export const GetPanelTeamsDocument = gql`
     }
     users {
       id
-      name
+      identify {
+        microsoftUserId
+      }
     }
   }
 }
@@ -2525,8 +2530,9 @@ export const GetPanelTeamDocument = gql`
     }
     users {
       id
-      name
-      email
+      identify {
+        microsoftUserId
+      }
     }
   }
 }
@@ -2568,8 +2574,9 @@ export const GetPanelMeDocument = gql`
     query GetPanelMe {
   me {
     id
-    name
-    email
+    identify {
+      microsoftUserId
+    }
     groups {
       id
       name
@@ -2617,8 +2624,9 @@ export const GetPanelUsersDocument = gql`
     query GetPanelUsers {
   users {
     id
-    name
-    email
+    identify {
+      microsoftUserId
+    }
     teams {
       id
       name
@@ -2662,8 +2670,9 @@ export const GetPanelUserDocument = gql`
     query GetPanelUser($id: ID!) {
   user(id: $id) {
     id
-    name
-    email
+    identify {
+      microsoftUserId
+    }
     groups {
       id
       name

--- a/apps/panel/src/hooks/useMsGraphUsers.ts
+++ b/apps/panel/src/hooks/useMsGraphUsers.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react'
+import { userManager } from '@/src/lib/userManager'
+import { fetchMsGraphUsers } from '@/src/lib/graphApi'
+import type { MsGraphUser } from '@/src/lib/graphApi'
+
+export function useMsGraphUsers(microsoftUserIds: string[]) {
+  const [msGraphUsers, setMsGraphUsers] = useState<Map<string, MsGraphUser>>(
+    new Map(),
+  )
+  const [loading, setLoading] = useState(false)
+  const cacheRef = useRef<Map<string, MsGraphUser>>(new Map())
+
+  const filtered = microsoftUserIds.filter(Boolean)
+  const sortedKey = [...new Set(filtered)].sort().join(',')
+
+  useEffect(() => {
+    if (!sortedKey) {
+      setMsGraphUsers(new Map())
+      return
+    }
+
+    const ids = sortedKey.split(',')
+    const uncachedIds = ids.filter((id) => !cacheRef.current.has(id))
+
+    if (uncachedIds.length === 0) {
+      const cached = new Map<string, MsGraphUser>()
+      for (const id of ids) {
+        const u = cacheRef.current.get(id)
+        if (u) cached.set(id, u)
+      }
+      setMsGraphUsers(cached)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+
+    ;(async () => {
+      try {
+        const user = await userManager.getUser()
+        if (!user?.access_token || cancelled) return
+
+        const fetched = await fetchMsGraphUsers(user.access_token, uncachedIds)
+        if (cancelled) return
+
+        for (const [id, u] of fetched) {
+          cacheRef.current.set(id, u)
+        }
+
+        const merged = new Map<string, MsGraphUser>()
+        for (const id of ids) {
+          const u = cacheRef.current.get(id)
+          if (u) merged.set(id, u)
+        }
+        setMsGraphUsers(merged)
+      } catch (e) {
+        console.error('Failed to fetch MS Graph users:', e)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [sortedKey])
+
+  return { msGraphUsers, loading }
+}

--- a/apps/panel/src/lib/graphApi.ts
+++ b/apps/panel/src/lib/graphApi.ts
@@ -1,0 +1,53 @@
+const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0'
+const CHUNK_SIZE = 15
+
+export type MsGraphUser = {
+  id: string
+  displayName: string
+  mail: string | null
+}
+
+export async function fetchMsGraphUsers(
+  accessToken: string,
+  microsoftUserIds: string[],
+): Promise<Map<string, MsGraphUser>> {
+  const result = new Map<string, MsGraphUser>()
+  if (microsoftUserIds.length === 0) return result
+
+  const unique = [...new Set(microsoftUserIds)]
+
+  const chunks: string[][] = []
+  for (let i = 0; i < unique.length; i += CHUNK_SIZE) {
+    chunks.push(unique.slice(i, i + CHUNK_SIZE))
+  }
+
+  const responses = await Promise.allSettled(
+    chunks.map(async (chunk) => {
+      const filter = chunk.map((id) => `'${id.replace(/'/g, "''")}'`).join(',')
+      const params = new URLSearchParams({
+        $filter: `id in (${filter})`,
+        $select: 'id,displayName,mail',
+      })
+      const url = `${GRAPH_BASE_URL}/users?${params.toString()}`
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      })
+      if (!res.ok) {
+        console.error(`Graph API error: ${res.status} ${res.statusText}`)
+        return []
+      }
+      const json = await res.json()
+      return (json.value ?? []) as MsGraphUser[]
+    }),
+  )
+
+  for (const response of responses) {
+    if (response.status === 'fulfilled') {
+      for (const user of response.value) {
+        result.set(user.id, user)
+      }
+    }
+  }
+
+  return result
+}


### PR DESCRIPTION
## Summary

- CSVインポートによるユーザー一括作成機能を実装（`batchCreateUsers` mutation）
- ユーザー作成時に `users_idp` レコード（`microsoft_user_id`）とグループ紐付けを同時作成
- セキュリティ要件に基づき、DBへの個人情報（name/email）の保存・読み取りを完全封鎖
- 全アプリ（admin/panel/form）のユーザー名表示を Microsoft Graph API 経由に移行

## 変更内容

### バックエンド
- `CreateUserInput` を `microsoftUserId` + `groupId` に変更（name/email 削除）
- `batchCreateUsers` mutation を新設（バッチ INSERT、1トランザクション、重複チェック・groupId存在チェック付き）
- `BatchSave` / `BatchSaveUserIdp` を repository 層に追加
- `updateUser` mutation を削除（name/email 書き込み経路の封鎖）
- GraphQL `User` type から `name` / `email` フィールドを完全削除（読み取り経路の封鎖）
- `UserIdentify.sub` を nullable に変更（CSV事前作成ユーザー対応）

### フロントエンド（admin）
- CSVインポートフローを改修: email → Graph API → `microsoftUserId` 解決 → `batchCreateUsers` 呼び出し
- `fetchMsGraphUsersByEmails` 関数を追加（ODataフィルタインジェクション対策済み）
- 全hooks の表示を Graph API 経由に切り替え

### フロントエンド（panel / form）
- `graphApi.ts` / `useMsGraphUsers.ts` を追加
- 全クエリに `identify { microsoftUserId }` を追加、`name` / `email` を削除
- panel: `useFetchUsers` / `useFetchUserinfo` で Graph API 名前解決を組み込み
- form: `useTeamEdit` に `resolveName` を追加

## セキュリティ

| 経路 | 状態 |
|------|------|
| API経由でname/emailをDBに書き込み | 封鎖（mutation/inputに該当フィールドなし） |
| API経由でname/emailをDBから読み取り | 封鎖（User typeからフィールド削除済み） |
| ユーザー名の表示 | Graph API経由のみ（OIDCログイン必須） |

## CSVインポートフロー

```
1. CSVテキスト入力（メールアドレス,クラス名）
2.「ユーザーを確認」→ Graph API で email → microsoftUserId を解決
3.「作成」→ batchCreateUsers mutation（1リクエスト、1トランザクション）
4. ログイン時 → SyncUser が microsoft_user_id で既存ユーザーを検索 → sub を更新 → 紐付け完了
```

## Test plan

- [ ] `go build ./...` が通ること
- [ ] admin / panel / form の `tsc --noEmit` または `yarn build` がエラーなく通ること
- [ ] admin でCSV（email,クラス名）を入力 →「ユーザーを確認」で Graph API からユーザー情報が取得されること
- [ ] 「作成」で batchCreateUsers が呼ばれ、users + users_idp + group_users が一括作成されること
- [ ] 重複する microsoftUserId を含むCSVでエラーが返ること
- [ ] 存在しないクラス名を含むCSVでエラーが返ること
- [ ] CSV作成済みユーザーがOIDCログインした際に、SyncUserが microsoft_user_id で既存ユーザーを検索し sub を自動更新すること
- [ ] admin / panel / form でユーザー名が Graph API 経由で表示されること
- [ ] GraphQL クエリで `user { name }` や `user { email }` をリクエストするとスキーマバリデーションエラーになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)