### PR TITLE
fix: rustfsのヘルスチェックエンドポイントを修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     volumes:
       - ${DATA_DIR:-./data}/rustfs:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/health"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- rustfsのヘルスチェックパスを `/minio/health/live` → `/health` に修正
- MinIOとrustfsではヘルスチェックのエンドポイントが異なるため、コンテナがunhealthyになり起動できなかった

## Test plan
- [ ] `docker compose up -d` でrustfsコンテナがhealthyになること
- [ ] `curl -f http://localhost:9000/health` が200を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)