### PR TITLE
fix: BusyBox版wgetに対応したヘルスチェックコマンドに修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
         VITE_BASE_PATH: /
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/api/healthz || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:8080/api/healthz || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -102,7 +102,7 @@ services:
         VITE_BASE_PATH: /admin/
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/api/healthz || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:8080/api/healthz || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -119,7 +119,7 @@ services:
         VITE_BASE_PATH: /form/
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/api/healthz || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:8080/api/healthz || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- panel/admin/formのヘルスチェックで `wget -qO-` → `wget -q -O -` に修正
- nginx:alpine内のBusyBox版wgetはオプションをまとめて書けないため、ヘルスチェックが常に失敗していた

## Test plan
- [ ] `docker compose up -d` でpanel/admin/formすべてhealthyになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)