### PR TITLE
fix: ヘルスチェックのlocalhostを127.0.0.1に変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
         VITE_BASE_PATH: /
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O - http://localhost:8080/api/healthz || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:8080/api/healthz || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -102,7 +102,7 @@ services:
         VITE_BASE_PATH: /admin/
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O - http://localhost:8080/api/healthz || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:8080/api/healthz || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -119,7 +119,7 @@ services:
         VITE_BASE_PATH: /form/
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O - http://localhost:8080/api/healthz || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:8080/api/healthz || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- panel/admin/formのヘルスチェックで `localhost` → `127.0.0.1` に変更
- Alpine Linux内でBusyBox版wgetが `localhost` をIPv6(`::1`)に解決し、IPv4のみリッスンするnginxに接続できずヘルスチェックが常に失敗していた

## Test plan
- [ ] `docker compose up -d` でpanel/admin/formすべてhealthyになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)