### PR TITLE
fix: CIのビルド引数参照をvarsからsecretsに変更

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -78,13 +78,13 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VITE_AUTHORITY=${{ vars.VITE_AUTHORITY }}
-            VITE_CLIENT_ID=${{ vars.VITE_CLIENT_ID }}
-            VITE_REDIRECT_URI=${{ vars.VITE_ADMIN_REDIRECT_URI }}
-            VITE_SILENT_REDIRECT_URI=${{ vars.VITE_ADMIN_SILENT_REDIRECT_URI }}
-            VITE_SCOPE=${{ vars.VITE_SCOPE }}
-            VITE_GRAPHQL_ENDPOINT=${{ vars.VITE_GRAPHQL_ENDPOINT }}
-            VITE_PANEL_URL=${{ vars.VITE_PANEL_URL }}
+            VITE_AUTHORITY=${{ secrets.VITE_AUTHORITY }}
+            VITE_CLIENT_ID=${{ secrets.VITE_CLIENT_ID }}
+            VITE_REDIRECT_URI=${{ secrets.VITE_ADMIN_REDIRECT_URI }}
+            VITE_SILENT_REDIRECT_URI=${{ secrets.VITE_ADMIN_SILENT_REDIRECT_URI }}
+            VITE_SCOPE=${{ secrets.VITE_SCOPE }}
+            VITE_GRAPHQL_ENDPOINT=${{ secrets.VITE_GRAPHQL_ENDPOINT }}
+            VITE_PANEL_URL=${{ secrets.VITE_PANEL_URL }}
 
   build-panel:
     name: Build Panel
@@ -119,14 +119,14 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VITE_AUTHORITY=${{ vars.VITE_AUTHORITY }}
-            VITE_CLIENT_ID=${{ vars.VITE_CLIENT_ID }}
-            VITE_REDIRECT_URI=${{ vars.VITE_PANEL_REDIRECT_URI }}
-            VITE_SILENT_REDIRECT_URI=${{ vars.VITE_PANEL_SILENT_REDIRECT_URI }}
-            VITE_SCOPE=${{ vars.VITE_SCOPE }}
-            VITE_OIDC_DISPLAY_NAME=${{ vars.VITE_OIDC_DISPLAY_NAME }}
-            VITE_GA_ID=${{ vars.VITE_GA_ID }}
-            VITE_GRAPHQL_ENDPOINT=${{ vars.VITE_GRAPHQL_ENDPOINT }}
+            VITE_AUTHORITY=${{ secrets.VITE_AUTHORITY }}
+            VITE_CLIENT_ID=${{ secrets.VITE_CLIENT_ID }}
+            VITE_REDIRECT_URI=${{ secrets.VITE_PANEL_REDIRECT_URI }}
+            VITE_SILENT_REDIRECT_URI=${{ secrets.VITE_PANEL_SILENT_REDIRECT_URI }}
+            VITE_SCOPE=${{ secrets.VITE_SCOPE }}
+            VITE_OIDC_DISPLAY_NAME=${{ secrets.VITE_OIDC_DISPLAY_NAME }}
+            VITE_GA_ID=${{ secrets.VITE_GA_ID }}
+            VITE_GRAPHQL_ENDPOINT=${{ secrets.VITE_GRAPHQL_ENDPOINT }}
 
   build-form:
     name: Build Form
@@ -161,9 +161,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VITE_AUTHORITY=${{ vars.VITE_AUTHORITY }}
-            VITE_CLIENT_ID=${{ vars.VITE_CLIENT_ID }}
-            VITE_REDIRECT_URI=${{ vars.VITE_FORM_REDIRECT_URI }}
-            VITE_SILENT_REDIRECT_URI=${{ vars.VITE_FORM_SILENT_REDIRECT_URI }}
-            VITE_SCOPE=${{ vars.VITE_SCOPE }}
-            VITE_GRAPHQL_ENDPOINT=${{ vars.VITE_GRAPHQL_ENDPOINT }}
+            VITE_AUTHORITY=${{ secrets.VITE_AUTHORITY }}
+            VITE_CLIENT_ID=${{ secrets.VITE_CLIENT_ID }}
+            VITE_REDIRECT_URI=${{ secrets.VITE_FORM_REDIRECT_URI }}
+            VITE_SILENT_REDIRECT_URI=${{ secrets.VITE_FORM_SILENT_REDIRECT_URI }}
+            VITE_SCOPE=${{ secrets.VITE_SCOPE }}
+            VITE_GRAPHQL_ENDPOINT=${{ secrets.VITE_GRAPHQL_ENDPOINT }}


### PR DESCRIPTION
## Summary
- GitHub Actionsワークフローのビルド引数参照を `vars.*` から `secrets.*` に変更
- VITE_*環境変数がRepository Secretsに登録されていたが、ワークフローが `vars.*` を参照していたためビルド時に空になっていた
- これによりOIDC認証（ログインボタン）が動作しない問題を修正

## Test plan
- [ ] mainマージ後、GitHub Actionsでイメージが正常にビルドされることを確認
- [ ] 本番サーバーで `docker compose pull && docker compose up -d` 後、ログインボタンが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)