### PR TITLE
fix: admin BrowserRouterにbasenameを追加し/admin/パスでのOIDCコールバックを修正

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -165,7 +165,7 @@ export default function App() {
   const [showPrivacy, setShowPrivacy] = useState(false)
 
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, '') || '/'}>
       <Suspense fallback={null}>
         {showPrivacy && (
           <PrivacyPolicyPage onClose={() => setShowPrivacy(false)} />

--- a/apps/form/src/App.tsx
+++ b/apps/form/src/App.tsx
@@ -36,7 +36,7 @@ export default function App() {
   return (
     <AppProviders>
       <AppErrorBoundary>
-        <BrowserRouter>
+        <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, '') || '/'}>
           <Routes>
             <Route path="/api/auth/callback" element={<AuthCallbackPage />} />
             <Route path="/login" element={<LoginRoute />} />


### PR DESCRIPTION
# やったこと

- /admin/パス配下でBrowserRouterにbasenameが未設定のため、OIDCコールバックルートがマッチせずトークンが保存されなかった問題を修正
