### PR TITLE
feat: 認証・ミドルウェアにzerologベースの観測性ログを追加

### DIFF
--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 
+	api "sports-day/api"
 	"sports-day/api/pkg/auth"
 	"sports-day/api/pkg/errors"
 )
@@ -14,12 +15,25 @@ func Auth(verifier *oidc.IDTokenVerifier) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			tokenString, err := auth.GetTokenFromRequest(r)
 			if err != nil {
+				api.Logger.Warn().
+					Str("event", "token_missing").
+					Str("method", r.Method).
+					Str("path", r.URL.Path).
+					Str("remote_addr", r.RemoteAddr).
+					Msg("Authorization header is missing or malformed")
 				http.Error(w, errors.ErrTokenMissing.Error(), http.StatusUnauthorized)
 				return
 			}
 
 			token, err := verifier.Verify(r.Context(), tokenString)
 			if err != nil {
+				api.Logger.Warn().
+					Err(err).
+					Str("event", "token_invalid").
+					Str("method", r.Method).
+					Str("path", r.URL.Path).
+					Str("remote_addr", r.RemoteAddr).
+					Msg("ID token verification failed")
 				http.Error(w, errors.ErrTokenInvalid.Error(), http.StatusUnauthorized)
 				return
 			}
@@ -30,14 +44,32 @@ func Auth(verifier *oidc.IDTokenVerifier) func(http.Handler) http.Handler {
 			}
 
 			if err := token.Claims(&claims); err != nil {
+				api.Logger.Warn().
+					Err(err).
+					Str("event", "token_claims_invalid").
+					Str("method", r.Method).
+					Str("path", r.URL.Path).
+					Msg("Failed to extract claims from token")
 				http.Error(w, errors.ErrTokenClaimsInvalid.Error(), http.StatusUnauthorized)
 				return
 			}
 
 			if claims.Sub == "" {
+				api.Logger.Warn().
+					Str("event", "token_claims_invalid").
+					Str("method", r.Method).
+					Str("path", r.URL.Path).
+					Msg("Token claims missing required 'sub' field")
 				http.Error(w, errors.ErrTokenClaimsInvalid.Error(), http.StatusUnauthorized)
 				return
 			}
+
+			api.Logger.Debug().
+				Str("event", "token_verified").
+				Str("sub", claims.Sub).
+				Str("method", r.Method).
+				Str("path", r.URL.Path).
+				Msg("ID token verified successfully")
 
 			ctx := auth.AttachClaims(r.Context(), &auth.Claims{
 				Sub:             claims.Sub,

--- a/api/middleware/user_sync.go
+++ b/api/middleware/user_sync.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 
+	api "sports-day/api"
 	"sports-day/api/pkg/auth"
 	pkgerrors "sports-day/api/pkg/errors"
 	"sports-day/api/service"
@@ -13,11 +14,28 @@ func UserSync(authService service.AuthService) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
+			claims, _ := auth.GetClaims(ctx)
+			sub := ""
+			if claims != nil {
+				sub = claims.Sub
+			}
+
 			if err := authService.SyncUser(ctx); err != nil {
 				if authErr, ok := err.(pkgerrors.Error); ok {
+					api.Logger.Warn().
+						Err(authErr).
+						Str("event", "user_sync_failed").
+						Str("sub", sub).
+						Str("error_code", authErr.Code()).
+						Msg("User sync failed with auth error")
 					http.Error(w, authErr.Error(), http.StatusUnauthorized)
 					return
 				}
+				api.Logger.Error().
+					Err(err).
+					Str("event", "user_sync_failed").
+					Str("sub", sub).
+					Msg("User sync failed with unexpected error")
 				http.Error(w, pkgerrors.ErrUserSyncFailed.Error(), http.StatusInternalServerError)
 				return
 			}
@@ -25,15 +43,34 @@ func UserSync(authService service.AuthService) func(http.Handler) http.Handler {
 			// sync後にユーザー情報を解決してcontextに注入
 			user, err := authService.GetCurrentUser(ctx)
 			if err != nil {
+				api.Logger.Warn().
+					Err(err).
+					Str("event", "user_resolve_failed").
+					Str("sub", sub).
+					Msg("Failed to resolve current user after sync")
 				http.Error(w, pkgerrors.ErrUnauthorized.Error(), http.StatusUnauthorized)
 				return
 			}
 
 			role, err := authService.GetRole(ctx, user.ID)
 			if err != nil {
+				api.Logger.Error().
+					Err(err).
+					Str("event", "role_resolve_failed").
+					Str("user_id", user.ID).
+					Str("sub", sub).
+					Msg("Failed to resolve user role")
 				http.Error(w, pkgerrors.ErrorServerPanic.Error(), http.StatusInternalServerError)
 				return
 			}
+
+			api.Logger.Debug().
+				Str("event", "auth_completed").
+				Str("user_id", user.ID).
+				Str("role", role).
+				Str("method", r.Method).
+				Str("path", r.URL.Path).
+				Msg("User authenticated successfully")
 
 			ctx = auth.AttachUser(ctx, &auth.AuthenticatedUser{
 				ID:   user.ID,

--- a/api/service/auth.go
+++ b/api/service/auth.go
@@ -5,6 +5,7 @@ import (
 
 	"gorm.io/gorm"
 
+	api "sports-day/api"
 	"sports-day/api/db_model"
 	"sports-day/api/pkg/auth"
 	"sports-day/api/pkg/authz"
@@ -72,9 +73,19 @@ func (s *AuthService) SyncUser(ctx context.Context) error {
 		return errors.Wrap(err)
 	}
 
+	api.Logger.Info().
+		Str("event", "user_provisioning").
+		Str("sub", claims.Sub).
+		Msg("New user detected, provisioning user and IDP record")
+
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		newUser := &db_model.User{ID: ulid.Make()}
 		if _, err := s.userRepo.Save(ctx, tx, newUser); err != nil {
+			api.Logger.Error().
+				Err(err).
+				Str("event", "user_save_failed").
+				Str("sub", claims.Sub).
+				Msg("Failed to save new user record")
 			return errors.ErrSaveUser
 		}
 
@@ -88,8 +99,21 @@ func (s *AuthService) SyncUser(ctx context.Context) error {
 		newIdp.MicrosoftUserID.Valid = claims.MicrosoftUserID != ""
 
 		if _, err := s.userRepo.SaveUserIdp(ctx, tx, newIdp); err != nil {
+			api.Logger.Error().
+				Err(err).
+				Str("event", "user_idp_save_failed").
+				Str("user_id", newUser.ID).
+				Str("sub", claims.Sub).
+				Msg("Failed to save IDP record for new user")
 			return errors.ErrSaveUserIdp
 		}
+
+		api.Logger.Info().
+			Str("event", "user_provisioned").
+			Str("user_id", newUser.ID).
+			Str("sub", claims.Sub).
+			Str("provider", "microsoft").
+			Msg("New user and IDP record created successfully")
 
 		return nil
 	})
@@ -148,6 +172,11 @@ func roleLevel(role string) int {
 func (s *AuthService) ChangeUserRole(ctx context.Context, callerID string, targetUserID string, newRole string) error {
 	// 自己変更防止
 	if callerID == targetUserID {
+		api.Logger.Warn().
+			Str("event", "role_change_denied").
+			Str("reason", "self_change").
+			Str("caller_id", callerID).
+			Msg("User attempted to change own role")
 		return errors.ErrSelfRoleChange
 	}
 
@@ -163,13 +192,38 @@ func (s *AuthService) ChangeUserRole(ctx context.Context, callerID string, targe
 		return err
 	}
 	if roleLevel(targetRole) > callerLevel {
+		api.Logger.Warn().
+			Str("event", "role_change_denied").
+			Str("reason", "target_higher_role").
+			Str("caller_id", callerID).
+			Str("caller_role", callerRole).
+			Str("target_user_id", targetUserID).
+			Str("target_role", targetRole).
+			Msg("Insufficient role to modify higher-level user")
 		return errors.ErrInsufficientRole
 	}
 
 	// 変更先ロールが自分より上なら不可
 	if roleLevel(newRole) > callerLevel {
+		api.Logger.Warn().
+			Str("event", "role_change_denied").
+			Str("reason", "new_role_higher").
+			Str("caller_id", callerID).
+			Str("caller_role", callerRole).
+			Str("target_user_id", targetUserID).
+			Str("new_role", newRole).
+			Msg("Insufficient role to assign higher-level role")
 		return errors.ErrInsufficientRole
 	}
+
+	api.Logger.Info().
+		Str("event", "role_changed").
+		Str("caller_id", callerID).
+		Str("caller_role", callerRole).
+		Str("target_user_id", targetUserID).
+		Str("old_role", targetRole).
+		Str("new_role", newRole).
+		Msg("User role changed")
 
 	return s.updateRole(ctx, targetUserID, newRole)
 }


### PR DESCRIPTION
# やったこと

- 認証フロー全体でログが欠如していたため、トークン検証・ユーザー同期・ロール解決の各段階にログを追加。 セキュリティイベント(ロール変更拒否等)はWarn/Info、成功系はDebugレベルで出力。

