### PR TITLE
fix: formアプリのユーザー名がnullになる問題を修正

### DIFF
--- a/apps/form/src/components/cards/AboutConfirmPage/hooks/useConflictedScenes.ts
+++ b/apps/form/src/components/cards/AboutConfirmPage/hooks/useConflictedScenes.ts
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { ApolloError } from "@apollo/client";
 import { SceneStatusItem } from "@/components/cards/AboutConfirmPage/SceneStatusCardLayout";
 import { useGetSceneIdQuery, useGetSceneUsersQuery } from "@/gql/__generated__/graphql";
+import { useMsGraphUsers } from "@/hooks/useMsGraphUsers";
 
 type HookResult = {
   items: SceneStatusItem[];
@@ -16,39 +17,63 @@ export function useConflictedScenes(): HookResult {
   const { data: sportSceneData, loading: sportSceneLoading, error: sportSceneError } =
     useGetSceneUsersQuery();
 
-  const loading = sceneLoading || sportSceneLoading;
+  const allUserMsIds = useMemo(() => {
+    const sportScenes = sportSceneData?.scenes?.filter((s) => !s.isDeleted)?.flatMap((s) => s.sportScenes) ?? [];
+    return sportScenes
+      .flatMap((ss) => ss.entries ?? [])
+      .flatMap((e) => e.team?.users ?? [])
+      .map((u) => u.identify?.microsoftUserId)
+      .filter((id): id is string => !!id);
+  }, [sportSceneData?.scenes]);
+  const { msGraphUsers, loading: msGraphLoading } = useMsGraphUsers(allUserMsIds);
+
+  const loading = sceneLoading || sportSceneLoading || msGraphLoading;
   const error = sceneError || sportSceneError || null;
 
   const items = useMemo(() => {
     const scenes = (sceneData?.scenes ?? []).filter((s) => !s.isDeleted);
     const sportScenes = sportSceneData?.scenes?.filter((s) => !s.isDeleted)?.flatMap((s) => s.sportScenes) ?? [];
-    const sceneUserNamesMap = new Map<string, string[]>();
 
+    // userId -> 表示名のマップを構築
+    const userIdToName = new Map<string, string>();
+    sportScenes
+      .flatMap((ss) => ss.entries ?? [])
+      .flatMap((e) => e.team?.users ?? [])
+      .forEach((user) => {
+        if (userIdToName.has(user.id)) return;
+        const msUser = user.identify?.microsoftUserId ? msGraphUsers.get(user.identify.microsoftUserId) : undefined;
+        const name = (msUser?.displayName ?? user.name)?.trim();
+        if (name) userIdToName.set(user.id, name);
+      });
+
+    // sceneId -> userId[] のマップを構築（IDベースで重複検出）
+    const sceneUserIdsMap = new Map<string, string[]>();
     sportScenes.forEach((sportScene) => {
       const sceneId = sportScene.scene?.id;
       if (!sceneId) return;
-      const names =
+      const ids =
         sportScene.entries?.flatMap((entry) =>
-          entry.team?.users?.map((user) => user.name?.trim()).filter((n): n is string => !!n) ?? [],
+          entry.team?.users?.map((user) => user.id).filter((id): id is string => !!id) ?? [],
         ) ?? [];
-      if (!sceneUserNamesMap.has(sceneId)) {
-        sceneUserNamesMap.set(sceneId, []);
+      if (!sceneUserIdsMap.has(sceneId)) {
+        sceneUserIdsMap.set(sceneId, []);
       }
-      sceneUserNamesMap.get(sceneId)?.push(...names);
+      sceneUserIdsMap.get(sceneId)?.push(...ids);
     });
 
     return scenes.map((scene) => {
-      const sceneUserNames = sceneUserNamesMap.get(scene.id) ?? [];
-      const nameCount: Record<string, number> = {};
-      sceneUserNames.forEach((name) => {
-        nameCount[name] = (nameCount[name] || 0) + 1;
+      const sceneUserIds = sceneUserIdsMap.get(scene.id) ?? [];
+      const idCount: Record<string, number> = {};
+      sceneUserIds.forEach((id) => {
+        idCount[id] = (idCount[id] || 0) + 1;
       });
+      const conflictedIds = Object.keys(idCount).filter((id) => idCount[id] > 1);
       return {
         scenename: scene.name,
-        users: Object.keys(nameCount).filter((name) => nameCount[name] > 1),
+        users: conflictedIds.map((id) => userIdToName.get(id) ?? id),
       };
     });
-  }, [sceneData?.scenes, sportSceneData?.scenes]);
+  }, [sceneData?.scenes, sportSceneData?.scenes, msGraphUsers]);
 
   return { items, loading, error };
 }

--- a/apps/form/src/components/cards/AboutConfirmPage/hooks/useNotSelectedScenes.ts
+++ b/apps/form/src/components/cards/AboutConfirmPage/hooks/useNotSelectedScenes.ts
@@ -8,6 +8,7 @@ import {
   useGetSceneIdQuery,
   useGetSceneUsersQuery,
 } from "@/gql/__generated__/graphql";
+import { useMsGraphUsers } from "@/hooks/useMsGraphUsers";
 
 type HookResult = {
   items: SceneStatusItem[];
@@ -22,15 +23,25 @@ export function useNotSelectedScenes(): HookResult {
   const { data: allUserData, loading: allUsersLoading, error: allUsersError } =
     useGetAllUsersQuery();
 
-  const loading = sceneLoading || sportSceneLoading || allUsersLoading;
+  const allUserMsIds = useMemo(() => {
+    return (allUserData?.users ?? [])
+      .map((u) => u.identify?.microsoftUserId)
+      .filter((id): id is string => !!id);
+  }, [allUserData?.users]);
+  const { msGraphUsers, loading: msGraphLoading } = useMsGraphUsers(allUserMsIds);
+
+  const loading = sceneLoading || sportSceneLoading || allUsersLoading || msGraphLoading;
   const error = sceneError || sportSceneError || allUsersError || null;
 
   const items = useMemo(() => {
     const allUsers =
-      allUserData?.users?.map((d) => ({
-        id: d.id?.trim(),
-        name: d.name?.trim(),
-      })) ?? [];
+      allUserData?.users?.map((d) => {
+        const msUser = d.identify?.microsoftUserId ? msGraphUsers.get(d.identify.microsoftUserId) : undefined;
+        return {
+          id: d.id?.trim(),
+          name: (msUser?.displayName ?? d.name)?.trim(),
+        };
+      }) ?? [];
     const scenes = (sceneData?.scenes ?? []).filter((s) => !s.isDeleted);
     const sportScenes = sportSceneData?.scenes?.filter((s) => !s.isDeleted)?.flatMap((s) => s.sportScenes) ?? [];
 
@@ -58,7 +69,7 @@ export function useNotSelectedScenes(): HookResult {
           .map((user) => user.name ?? ''),
       };
     });
-  }, [allUserData?.users, sceneData?.scenes, sportSceneData?.scenes]);
+  }, [allUserData?.users, sceneData?.scenes, sportSceneData?.scenes, msGraphUsers]);
 
   return { items, loading, error };
 }

--- a/apps/form/src/features/ConfirmPage.tsx
+++ b/apps/form/src/features/ConfirmPage.tsx
@@ -10,6 +10,7 @@ import {
   useGetAllTeamdataQuery,
   useGetAllSportExperiencesQuery,
 } from "@/gql/__generated__/graphql";
+import { useMsGraphUsers } from "@/hooks/useMsGraphUsers";
 
 export default function ConfirmPage() {
   const theme = useTheme();
@@ -19,6 +20,19 @@ export default function ConfirmPage() {
   const { data: expData, loading: expLoading } = useGetAllSportExperiencesQuery({
     fetchPolicy: "cache-and-network",
   });
+
+  const allUserMsIds = (data?.scenes ?? [])
+    .filter((s) => !s.isDeleted)
+    .flatMap((s) => s.sportScenes ?? [])
+    .flatMap((d) => d.entries ?? [])
+    .flatMap((e) => e.team?.users ?? [])
+    .map((u) => u.identify?.microsoftUserId)
+    .filter((id): id is string => !!id);
+  const { msGraphUsers, loading: msGraphLoading } = useMsGraphUsers(allUserMsIds);
+
+  if (loading || expLoading || msGraphLoading) {
+    return <CircularUnderLoad />;
+  }
 
   // sportId+userId のセットで経験者判定
   const experiencedSet = new Set(
@@ -37,15 +51,11 @@ export default function ConfirmPage() {
       teamId: d.entries?.map((s) => s.team?.id ?? "") ?? [],
       memberData: d.entries?.map((s) =>
         s.team?.users?.map((u) => ({
-          name: u.name ?? '',
+          name: (u.identify?.microsoftUserId ? msGraphUsers.get(u.identify.microsoftUserId)?.displayName : undefined) ?? u.name ?? '',
           isExperienced: experiencedSet.has(`${d.sport?.id}:${u.id}`),
         })) ?? [],
       ) ?? [],
     }));
-
-  if (loading || expLoading) {
-    return <CircularUnderLoad />;
-  }
 
   return (
     <Box

--- a/apps/form/src/features/MakingTeams.tsx
+++ b/apps/form/src/features/MakingTeams.tsx
@@ -14,6 +14,7 @@ import {
   useGetSceneSportQuery,
   useGetSportExperienceQuery,
 } from "@/gql/__generated__/graphql";
+import { useMsGraphUsers } from "@/hooks/useMsGraphUsers";
 
 type MakingProps = {
   sports: string;
@@ -46,7 +47,13 @@ export default function MakingTeams({
     { label: "チーム確認" },
   ];
 
-  if (loading) {
+  const allUserMsIds = teams
+    .flatMap((d) => d.entries.flatMap((e) => e.team?.users ?? []))
+    .map((u) => u.identify?.microsoftUserId)
+    .filter((id): id is string => !!id);
+  const { msGraphUsers, loading: msGraphLoading } = useMsGraphUsers(allUserMsIds);
+
+  if (loading || msGraphLoading) {
     return <CircularUnderLoad />;
   }
 
@@ -158,7 +165,7 @@ export default function MakingTeams({
                         sports={sports}
                         member={item.users.map((u) => ({
                           id: u.id,
-                          name: u.name ?? '',
+                          name: (u.identify?.microsoftUserId ? msGraphUsers.get(u.identify.microsoftUserId)?.displayName : undefined) ?? u.name ?? '',
                           isExperienced: experiencedUserIds.has(u.id),
                         }))}
                       />

--- a/apps/form/src/features/hooks/useTeamEdit.ts
+++ b/apps/form/src/features/hooks/useTeamEdit.ts
@@ -134,11 +134,12 @@ export function useTeamEdit() {
 
   const filteredUsers = useMemo(() => {
     if (!userData?.users) return [];
-    return userData.users.filter((u) => {
-      if (searchName === "") return true;
-      const displayName = resolveName(u);
-      return displayName.includes(searchName);
-    });
+    return userData.users
+      .filter((u) => {
+        if (searchName === "") return true;
+        return resolveName(u).includes(searchName);
+      })
+      .map((u) => ({ ...u, name: resolveName(u) }));
   }, [userData?.users, searchName, resolveName]);
 
   const myTeamUserIds = useMemo(() => {


### PR DESCRIPTION
# やったこと

DBのusers.nameカラムが全ユーザーNULLのため、MS Graph APIから
displayNameを取得して表示する必要があるが、複数箇所でGraphQLの
生データ(name: null)をそのまま表示していた。

- useTeamEdit: filteredUsersのmapにresolveName適用
- MakingTeams: useMsGraphUsersを追加しメンバー名を解決
- ConfirmPage: useMsGraphUsersを追加しメンバー名を解決、allDataをloading後に計算するよう移動
- useConflictedScenes: useMsGraphUsersを追加し重複検出をID基準に変更
- useNotSelectedScenes: useMsGraphUsersを追加しユーザー名を解決


