### PR TITLE
fix(competition): sport_id をNOT NULLに変更しGraphQLのnull propagationエラーを修正

### DIFF
--- a/api/db_model/competition.xo.go
+++ b/api/db_model/competition.xo.go
@@ -13,7 +13,7 @@ type Competition struct {
 	Name              string         `json:"name"`                // 大会名
 	Type              string         `json:"type"`                // 大会種別
 	SceneID           string         `json:"scene_id"`            // シーンID
-	SportID           sql.NullString `json:"sport_id"`            // 競技ID
+	SportID           string         `json:"sport_id"`            // 競技ID
 	StartTime         sql.NullTime   `json:"start_time"`          // スケジュール開始時刻
 	MatchDuration     sql.NullInt64  `json:"match_duration"`      // 試合時間（分）
 	BreakDuration     sql.NullInt64  `json:"break_duration"`      // 休憩時間（分）

--- a/api/db_schema/migrations/20260415014135_make_sport_id_not_null_in_competitions.sql
+++ b/api/db_schema/migrations/20260415014135_make_sport_id_not_null_in_competitions.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+-- sport_id が NULL の competitions を削除する（関連データは FK CASCADE で自動削除）
+-- 対象: competition_entries, leagues, matches, match_entries, judgments,
+--       tournaments, tournament_slots, promotion_rules
+DELETE FROM competitions WHERE sport_id IS NULL;
+
+-- sport_id を NOT NULL に変更
+ALTER TABLE competitions
+  MODIFY COLUMN sport_id VARCHAR(26) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT '競技ID';
+
+-- migrate:down
+ALTER TABLE competitions
+  MODIFY COLUMN sport_id VARCHAR(26) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL COMMENT '競技ID';

--- a/api/graph/model/format_response.go
+++ b/api/graph/model/format_response.go
@@ -123,10 +123,7 @@ func FormatLocationResponse(location *db_model.Location) *Location {
 }
 
 func FormatCompetitionResponse(competition *db_model.Competition) *Competition {
-	var sportID string
-	if competition.SportID.Valid {
-		sportID = competition.SportID.String
-	}
+	sportID := competition.SportID
 	var startTime *string
 	if competition.StartTime.Valid {
 		s := competition.StartTime.Time.Format(time.RFC3339)

--- a/api/service/competition.go
+++ b/api/service/competition.go
@@ -62,7 +62,7 @@ func (s *Competition) Create(ctx context.Context, input *model.CreateCompetition
 			Name:         input.Name,
 			Type:         input.Type.String(),
 			SceneID:      input.SceneID,
-			SportID:      sql.NullString{Valid: true, String: input.SportID},
+			SportID:      input.SportID,
 			DisplayOrder: maxOrder + 1,
 		}
 
@@ -128,7 +128,7 @@ func (s *Competition) Update(ctx context.Context, id string, input model.UpdateC
 		competition.SceneID = *input.SceneID
 	}
 	if input.SportID != nil {
-		competition.SportID = sql.NullString{Valid: true, String: *input.SportID}
+		competition.SportID = *input.SportID
 	}
 
 	competition, err = s.competitionRepository.Save(ctx, s.db, competition)
@@ -1123,8 +1123,8 @@ func (s *Competition) computeStandingsForPromotion(ctx context.Context, tx *gorm
 	}
 
 	var rankingRules []*db_model.RankingRule
-	if comp.SportID.Valid {
-		rankingRules, err = s.sportsRepository.ListRankingRules(ctx, tx, comp.SportID.String)
+	if comp.SportID != "" {
+		rankingRules, err = s.sportsRepository.ListRankingRules(ctx, tx, comp.SportID)
 		if err != nil {
 			return nil, errors.Wrap(err)
 		}

--- a/api/service/league.go
+++ b/api/service/league.go
@@ -56,7 +56,7 @@ func (s *League) Create(ctx context.Context, input *model.CreateLeagueInput) (*d
 			Name:    input.Name,
 			Type:    string(model.CompetitionTypeLeague),
 			SceneID: input.SceneID,
-			SportID: sql.NullString{Valid: true, String: input.SportID},
+			SportID: input.SportID,
 		}
 
 		if _, err := s.competitionRepository.Save(ctx, tx, competition); err != nil {
@@ -442,8 +442,8 @@ func (s *League) ComputeStandings(ctx context.Context, leagueID string) ([]*mode
 
 	// 2. ranking_rules を取得（sport_id 経由）
 	var rankingRules []*db_model.RankingRule
-	if comp.SportID.Valid {
-		rankingRules, err = s.sportsRepository.ListRankingRules(ctx, s.db, comp.SportID.String)
+	if comp.SportID != "" {
+		rankingRules, err = s.sportsRepository.ListRankingRules(ctx, s.db, comp.SportID)
 		if err != nil {
 			return nil, errors.Wrap(err)
 		}


### PR DESCRIPTION
# やったこと

sport_idがNULLの競技データによりsport: Sport!フィールドにnilが返され、
matchesクエリ全体がnull propagationでエラーになる問題を修正。

- マイグレーション: sport_id IS NULLの競技を削除しNOT NULL制約を追加
- competition.xo.go: SportID型をsql.NullStringからstringに変更
- format_response.go: SportID参照をNullString→直接参照に変更
- competition.go / league.go: SportID代入・参照をstring型に対応


