### PR TITLE
fix(sports): 画像解除が保存されないバグを修正

### DIFF
--- a/api/repository/sports.go
+++ b/api/repository/sports.go
@@ -24,6 +24,11 @@ type Sports interface {
 		sportID string,
 		imageID string,
 	) error
+	ClearImageID(
+		ctx context.Context,
+		db *gorm.DB,
+		sportID string,
+	) error
 
 	ListAllExperiences(ctx context.Context, db *gorm.DB) ([]*db_model.SportExperience, error)
 	ListExperiencesBySportID(ctx context.Context, db *gorm.DB, sportID string) ([]*db_model.SportExperience, error)

--- a/api/repository/sports_sql.go
+++ b/api/repository/sports_sql.go
@@ -132,6 +132,17 @@ func (r sports) UpdateImageID(ctx context.Context, db *gorm.DB, sportID string, 
 	return nil
 }
 
+func (r sports) ClearImageID(ctx context.Context, db *gorm.DB, sportID string) error {
+	if err := db.WithContext(ctx).
+		Model(&db_model.Sport{}).
+		Where("id = ?", sportID).
+		Update("image_id", nil).
+		Error; err != nil {
+		return errors.Wrap(err)
+	}
+	return nil
+}
+
 func (r sports) ListAllExperiences(ctx context.Context, db *gorm.DB) ([]*db_model.SportExperience, error) {
 	var exps []*db_model.SportExperience
 	if err := db.WithContext(ctx).Find(&exps).Error; err != nil {

--- a/api/service/sports.go
+++ b/api/service/sports.go
@@ -104,10 +104,14 @@ func (s *Sport) Update(ctx context.Context, id string, input model.UpdateSportsI
 			if err := s.sportsRepository.UpdateImageID(ctx, tx, id, *input.ImageID); err != nil {
 				return errors.Wrap(err)
 			}
-			sport, err = s.sportsRepository.Get(ctx, tx, id)
-			if err != nil {
+		} else {
+			if err := s.sportsRepository.ClearImageID(ctx, tx, id); err != nil {
 				return errors.Wrap(err)
 			}
+		}
+		sport, err = s.sportsRepository.Get(ctx, tx, id)
+		if err != nil {
+			return errors.Wrap(err)
 		}
 
 		result = sport


### PR DESCRIPTION
# やったこと

- imageId=nullを送信した際にClearImageIDを呼ぶことで
- DBのimage_idをNULLに更新するよう修正した。
