### PR TITLE
fix(ui): 全アプリのテキストオーバーフローによるレイアウト崩れを修正

### DIFF
--- a/apps/admin/src/features/classes/components/ClassDetailPage.tsx
+++ b/apps/admin/src/features/classes/components/ClassDetailPage.tsx
@@ -24,6 +24,7 @@ import { showToast } from '@/lib/toast'
 import { AddClassMemberDialog } from './AddClassMemberDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import {
+  CARD_TABLE_SX,
   CARD_TABLE_HEAD_SX,
   CARD_TABLE_CELL_SX,
   CARD_FIELD_SX,
@@ -144,10 +145,10 @@ export function ClassDetailPage({ classId, onBack }: Props) {
 
       <Card elevation={0} sx={{ background: CARD_GRADIENT }}>
         <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-          <Typography sx={{ fontSize: '16px', fontWeight: 600, color: '#2F3C8C', mb: 2 }}>
+          <Typography noWrap sx={{ fontSize: '16px', fontWeight: 600, color: '#2F3C8C', mb: 2 }}>
             {className}のメンバー
           </Typography>
-          <Table>
+          <Table sx={CARD_TABLE_SX}>
             <TableHead>
               <TableRow>
                 {['名前', 'メール', ''].map((header, i) => (

--- a/apps/admin/src/features/classes/components/ClassListPage.tsx
+++ b/apps/admin/src/features/classes/components/ClassListPage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mui/material'
 import { useClasses } from '../hooks/useClasses'
 import { QueryError } from '@/components/ui/QueryError'
-import { CARD_GRADIENT, ACTION_BUTTON_SX, LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX } from '@/styles/commonSx'
+import { CARD_GRADIENT, ACTION_BUTTON_SX, LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, LIST_TABLE_SX } from '@/styles/commonSx'
 import { SearchFilterBar } from '@/components/ui/SearchFilterBar'
 
 type Props = {
@@ -61,7 +61,7 @@ export function ClassListPage({ onCreateClick, onClassClick }: Props) {
           </Box>
 
           <Box sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflowX: 'auto' }}>
-            <Table size="small" sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflow: 'hidden', width: '100%' }}>
+            <Table size="small" sx={LIST_TABLE_SX}>
               <TableHead>
                 <TableRow>
                   <TableCell sx={LIST_TABLE_HEAD_SX}>クラス名</TableCell>

--- a/apps/admin/src/features/competitions/components/CompetitionCard.tsx
+++ b/apps/admin/src/features/competitions/components/CompetitionCard.tsx
@@ -26,10 +26,10 @@ export function CompetitionCard({ competition, onSelect, dragHandle }: Competiti
         '&:focus-visible': { outline: 'none' },
       }}
     >
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%', overflow: 'hidden' }}>
         {dragHandle}
-        <GroupsIcon sx={{ fontSize: 20, color: '#4A5ABB' }} />
-        <Typography sx={{ fontSize: '14px', color: '#2F3C8C', fontWeight: 400 }}>
+        <GroupsIcon sx={{ fontSize: 20, color: '#4A5ABB', flexShrink: 0 }} />
+        <Typography noWrap sx={{ fontSize: '14px', color: '#2F3C8C', fontWeight: 400, minWidth: 0 }}>
           {competition.name}
         </Typography>
       </Box>

--- a/apps/admin/src/features/competitions/components/LeagueDetailPage.tsx
+++ b/apps/admin/src/features/competitions/components/LeagueDetailPage.tsx
@@ -29,7 +29,7 @@ import { AddEntryDialog } from './AddEntryDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { SportSelect } from './SportSelect'
 import { SceneSelect } from '@/components/ui/SceneSelect'
-import { BREADCRUMB_LINK_SX, BREADCRUMB_CURRENT_SX, CARD_TABLE_HEAD_SX, CARD_TABLE_CELL_SX, CARD_GRADIENT, CARD_FIELD_SX, SAVE_BUTTON_SX, DELETE_BUTTON_SX } from '@/styles/commonSx'
+import { BREADCRUMB_LINK_SX, BREADCRUMB_CURRENT_SX, CARD_TABLE_SX, CARD_TABLE_HEAD_SX, CARD_TABLE_CELL_SX, CARD_GRADIENT, CARD_FIELD_SX, SAVE_BUTTON_SX, DELETE_BUTTON_SX } from '@/styles/commonSx'
 import { DateTimeInput } from '@/components/ui/DateTimeInput'
 import { NumberInput } from '@/components/ui/NumberInput'
 import { showToast } from '@/lib/toast'
@@ -294,7 +294,7 @@ export function LeagueDetailPage({ leagueId, leagueName, competitionId, competit
       {leagueStandings && leagueStandings.matches.length > 0 && (
         <Card elevation={0} sx={{ background: CARD_GRADIENT, overflow: 'hidden' }}>
           <CardContent sx={{ pb: '12px !important', overflow: 'hidden' }}>
-            <Typography sx={{ fontSize: '16px', fontWeight: 600, color: '#2F3C8C', mb: 1.5 }}>
+            <Typography noWrap sx={{ fontSize: '16px', fontWeight: 600, color: '#2F3C8C', mb: 1.5 }}>
               {leagueName} リーグ表
             </Typography>
             <Box sx={{ overflowX: 'auto', mx: 0.5 }}>
@@ -422,10 +422,10 @@ export function LeagueDetailPage({ leagueId, leagueName, competitionId, competit
       {/* エントリーカード */}
       <Card elevation={0} sx={{ background: CARD_GRADIENT }}>
         <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-          <Typography sx={{ fontSize: '16px', fontWeight: 600, color: '#2F3C8C', mb: 2 }}>
+          <Typography noWrap sx={{ fontSize: '16px', fontWeight: 600, color: '#2F3C8C', mb: 2 }}>
             {leagueName}のエントリー
           </Typography>
-          <Table>
+          <Table sx={CARD_TABLE_SX}>
             <TableHead>
               <TableRow>
                 {['チーム名', 'クラス', ''].map((header, i) => (

--- a/apps/admin/src/features/images/components/ImageListPage.tsx
+++ b/apps/admin/src/features/images/components/ImageListPage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mui/material'
 import { useImages } from '../hooks/useImages'
 import { QueryError } from '@/components/ui/QueryError'
-import { LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, CARD_GRADIENT, ACTION_BUTTON_SX } from '@/styles/commonSx'
+import { LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, LIST_TABLE_SX, CARD_GRADIENT, ACTION_BUTTON_SX } from '@/styles/commonSx'
 
 const CLICKABLE_CELL_SX = {
   ...LIST_TABLE_CELL_SX,
@@ -57,7 +57,7 @@ export function ImageListPage({ onCreateClick, onImageClick }: Props) {
           </Box>
 
           <Box sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflowX: 'auto' }}>
-            <Table size="small" sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflow: 'hidden', width: '100%' }}>
+            <Table size="small" sx={LIST_TABLE_SX}>
               <TableHead>
                 <TableRow>
                   <TableCell sx={{ ...LIST_TABLE_HEAD_SX, width: 56 }}>プレビュー</TableCell>

--- a/apps/admin/src/features/information/components/InformationListPage.tsx
+++ b/apps/admin/src/features/information/components/InformationListPage.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mui/material'
 import { useAnnouncements } from '../hooks/useAnnouncements'
 import { QueryError } from '@/components/ui/QueryError'
-import { LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, CARD_GRADIENT, ACTION_BUTTON_SX } from '@/styles/commonSx'
+import { LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, LIST_TABLE_SX, CARD_GRADIENT, ACTION_BUTTON_SX } from '@/styles/commonSx'
 import { DragHandle } from '@/components/ui/DragHandle'
 import { useDisplayOrderDnD } from '@/hooks/useDisplayOrderDnD'
 import { useUpdateAdminInformationsDisplayOrderMutation } from '@/gql/__generated__/graphql'
@@ -69,7 +69,7 @@ export function InformationListPage({ onCreateClick, onAnnouncementClick }: Prop
           </Box>
 
           <Box sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflowX: 'auto' }}>
-            <Table size="small" sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflow: 'hidden', width: '100%' }}>
+            <Table size="small" sx={LIST_TABLE_SX}>
               <TableHead>
                 <TableRow>
                   <TableCell sx={{ ...LIST_TABLE_HEAD_SX, width: 40, px: 0.5 }} />

--- a/apps/admin/src/features/locations/components/LocationListPage.tsx
+++ b/apps/admin/src/features/locations/components/LocationListPage.tsx
@@ -14,7 +14,7 @@ import {
 import AddIcon from '@mui/icons-material/Add'
 import { useLocations } from '../hooks/useLocations'
 import { QueryError } from '@/components/ui/QueryError'
-import { LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, CARD_GRADIENT, ACTION_BUTTON_SX } from '@/styles/commonSx'
+import { LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, LIST_TABLE_SX, CARD_GRADIENT, ACTION_BUTTON_SX } from '@/styles/commonSx'
 import { SearchFilterBar } from '@/components/ui/SearchFilterBar'
 
 type Props = {
@@ -61,7 +61,7 @@ export function LocationListPage({ onNavigateToCreate, onSelectLocation }: Props
           </Box>
 
           <Box sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflowX: 'auto' }}>
-            <Table size="small" sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflow: 'hidden', width: '100%' }}>
+            <Table size="small" sx={LIST_TABLE_SX}>
               <TableHead>
                 <TableRow>
                   <TableCell sx={LIST_TABLE_HEAD_SX}>名前</TableCell>

--- a/apps/admin/src/features/sports/components/SportListPage.tsx
+++ b/apps/admin/src/features/sports/components/SportListPage.tsx
@@ -211,18 +211,18 @@ export function SportListPage({ onNavigateToCreate, onSelectSport }: Props) {
                       '&:focus-visible': { outline: 'none' },
                     }}
                   >
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%', overflow: 'hidden' }}>
                       <DragHandle disabled={hasFilter} />
                       {sport.imageUrl ? (
                         <Box
                           component="img"
                           src={sport.imageUrl}
-                          sx={{ width: 24, height: 24, borderRadius: 0.5, objectFit: 'cover' }}
+                          sx={{ width: 24, height: 24, borderRadius: 0.5, objectFit: 'cover', flexShrink: 0 }}
                         />
                       ) : (
-                        <SportsIcon sx={{ fontSize: 20, color: '#4A5ABB' }} />
+                        <SportsIcon sx={{ fontSize: 20, color: '#4A5ABB', flexShrink: 0 }} />
                       )}
-                      <Typography sx={{ fontSize: '14px', color: '#2F3C8C', fontWeight: 400 }}>
+                      <Typography noWrap sx={{ fontSize: '14px', color: '#2F3C8C', fontWeight: 400, minWidth: 0 }}>
                         {sport.name}
                       </Typography>
                     </Box>

--- a/apps/admin/src/features/tags/components/TagListPage.tsx
+++ b/apps/admin/src/features/tags/components/TagListPage.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mui/material'
 import { useTags } from '../hooks/useTags'
 import { QueryError } from '@/components/ui/QueryError'
-import { CARD_GRADIENT, ACTION_BUTTON_SX, LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX } from '@/styles/commonSx'
+import { CARD_GRADIENT, ACTION_BUTTON_SX, LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, LIST_TABLE_SX } from '@/styles/commonSx'
 import { SearchFilterBar, type FilterDef } from '@/components/ui/SearchFilterBar'
 
 type Props = {
@@ -87,7 +87,7 @@ export function TagListPage({ onCreateClick, onTagClick }: Props) {
           </Box>
 
           <Box sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflowX: 'auto' }}>
-          <Table size="small" sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflow: 'hidden', width: '100%' }}>
+          <Table size="small" sx={LIST_TABLE_SX}>
             <TableHead>
               <TableRow>
                 <TableCell sx={LIST_TABLE_HEAD_SX}>名前</TableCell>

--- a/apps/admin/src/features/teams/components/TeamDetailPage.tsx
+++ b/apps/admin/src/features/teams/components/TeamDetailPage.tsx
@@ -25,6 +25,7 @@ import { AddMemberDialog } from './AddMemberDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { SceneSelect } from '@/components/ui/SceneSelect'
 import {
+  CARD_TABLE_SX,
   CARD_TABLE_HEAD_SX,
   CARD_TABLE_CELL_SX,
   CARD_FIELD_SX,
@@ -160,10 +161,10 @@ export function TeamDetailPage({ teamId, onBack }: Props) {
       {/* メンバーカード */}
       <Card elevation={0} sx={{ background: CARD_GRADIENT }}>
         <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-          <Typography sx={{ fontSize: '16px', fontWeight: 600, color: '#2F3C8C', mb: 2 }}>
+          <Typography noWrap sx={{ fontSize: '16px', fontWeight: 600, color: '#2F3C8C', mb: 2 }}>
             {teamName}のメンバー
           </Typography>
-          <Table>
+          <Table sx={CARD_TABLE_SX}>
             <TableHead>
               <TableRow>
                 {['学籍番号', '名前', ''].map((header, i) => (

--- a/apps/admin/src/features/teams/components/TeamListPage.tsx
+++ b/apps/admin/src/features/teams/components/TeamListPage.tsx
@@ -15,7 +15,7 @@ import {
 import AddIcon from '@mui/icons-material/Add'
 import { useTeams } from '../hooks/useTeams'
 import { QueryError } from '@/components/ui/QueryError'
-import { LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, CARD_GRADIENT, ACTION_BUTTON_SX } from '@/styles/commonSx'
+import { LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, LIST_TABLE_SX, CARD_GRADIENT, ACTION_BUTTON_SX } from '@/styles/commonSx'
 import { SearchFilterBar, type FilterDef } from '@/components/ui/SearchFilterBar'
 
 type Props = {
@@ -82,7 +82,7 @@ export function TeamListPage({ onTeamClick, onNavigateToCreate }: Props) {
           </Box>
 
           <Box sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflowX: 'auto' }}>
-            <Table size="small" sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflow: 'hidden', width: '100%' }}>
+            <Table size="small" sx={LIST_TABLE_SX}>
               <TableHead>
                 <TableRow>
                   <TableCell sx={LIST_TABLE_HEAD_SX}>チーム名</TableCell>

--- a/apps/admin/src/features/users/components/UserListPage.tsx
+++ b/apps/admin/src/features/users/components/UserListPage.tsx
@@ -15,7 +15,7 @@ import {
 import UploadFileIcon from '@mui/icons-material/UploadFile'
 import { useUsers } from '../hooks/useUsers'
 import { QueryError } from '@/components/ui/QueryError'
-import { LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, CARD_GRADIENT, ACTION_BUTTON_SX } from '@/styles/commonSx'
+import { LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, LIST_TABLE_SX, CARD_GRADIENT, ACTION_BUTTON_SX } from '@/styles/commonSx'
 import { SearchFilterBar, type FilterDef } from '@/components/ui/SearchFilterBar'
 
 type Props = {
@@ -93,7 +93,7 @@ export function UserListPage({ onCsvCreate, onUserClick }: Props) {
           </Box>
 
           <Box sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflowX: 'auto' }}>
-          <Table size="small" sx={{ backgroundColor: '#FFFFFF', borderRadius: 1, overflow: 'hidden', width: '100%' }}>
+          <Table size="small" sx={LIST_TABLE_SX}>
             <TableHead>
               <TableRow>
                 <TableCell sx={LIST_TABLE_HEAD_SX}>学籍番号</TableCell>

--- a/apps/admin/src/styles/commonSx.ts
+++ b/apps/admin/src/styles/commonSx.ts
@@ -10,6 +10,12 @@ import {
 // カードのグラデーション背景
 export const CARD_GRADIENT = 'linear-gradient(to bottom, #E0E3F5 30%, #D2D6ED 70%)'
 
+// グラデーションカード内テーブル コンテナ（テキストオーバーフロー対応）
+export const CARD_TABLE_SX = {
+  tableLayout: 'fixed' as const,
+  width: '100%',
+}
+
 // グラデーションカード内テーブル（透明背景）
 export const CARD_TABLE_HEAD_SX = {
   fontSize: '13px',
@@ -20,6 +26,9 @@ export const CARD_TABLE_HEAD_SX = {
   borderLeft: 'none',
   borderRight: 'none',
   borderTop: 'none',
+  whiteSpace: 'nowrap' as const,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
 }
 
 export const CARD_TABLE_CELL_SX = {
@@ -27,6 +36,18 @@ export const CARD_TABLE_CELL_SX = {
   color: COLOR_PRIMARY_DARK,
   backgroundColor: 'transparent',
   border: 'none',
+  whiteSpace: 'nowrap' as const,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+}
+
+// リスト・ダイアログ内テーブル コンテナ（テキストオーバーフロー対応）
+export const LIST_TABLE_SX = {
+  backgroundColor: '#FFFFFF',
+  borderRadius: 1,
+  overflow: 'hidden',
+  width: '100%',
+  tableLayout: 'fixed' as const,
 }
 
 // リスト・ダイアログ内テーブル（白背景）
@@ -121,4 +142,8 @@ export const BREADCRUMB_LINK_SX = {
 export const BREADCRUMB_CURRENT_SX = {
   fontSize: '16px',
   color: COLOR_PRIMARY_DARK,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap' as const,
+  maxWidth: '40vw',
 }

--- a/apps/form/src/components/cards/AboutConfirmPage/ConfirmCard.tsx
+++ b/apps/form/src/components/cards/AboutConfirmPage/ConfirmCard.tsx
@@ -57,6 +57,7 @@ export default function ConfirmCard({
       }}
     >
       <Typography
+        noWrap
         component="legend"
         sx={(theme) => ({
           ...theme.typography.buttonFont3,

--- a/apps/form/src/components/cards/AboutConfirmPage/SceneStatusCardLayout.tsx
+++ b/apps/form/src/components/cards/AboutConfirmPage/SceneStatusCardLayout.tsx
@@ -82,7 +82,7 @@ export default function SceneStatusCardLayout({
                 alignItems: "center",
               }}
             >
-              <Typography>{statusMessage}</Typography>
+              <Typography noWrap sx={{ maxWidth: '100%' }}>{statusMessage}</Typography>
             </Stack>
           ) : (
             <Stack spacing={"16px"}>
@@ -101,6 +101,7 @@ export default function SceneStatusCardLayout({
                   }}
                 >
                   <Typography
+                    noWrap
                     sx={(theme) => ({
                       ...theme.typography.buttonFont2,
                       flexGrow: 1,

--- a/apps/form/src/components/cards/AboutMakingTeamPage/TeamCard.tsx
+++ b/apps/form/src/components/cards/AboutMakingTeamPage/TeamCard.tsx
@@ -41,10 +41,11 @@ export default function TeamCard({
         flexDirection: "column",
       }}
     >
-      <Box sx={{ pb: "8px" }}>
+      <Box sx={{ pb: "8px", px: "8px" }}>
         <Typography
+          noWrap
           align="center"
-          sx={(theme) => ({ ...theme.typography.buttonFont3 })}
+          sx={(theme) => ({ ...theme.typography.buttonFont3, width: '100%' })}
         >
           {teamname}
         </Typography>
@@ -85,7 +86,7 @@ export default function TeamCard({
                   }}
                 />
               )}
-              <Typography sx={{ color: "white" }}>{item.name}</Typography>
+              <Typography noWrap sx={{ color: "white", minWidth: 0, width: '100%', textAlign: 'center' }}>{item.name}</Typography>
             </Card>
           ))}
         </Stack>

--- a/apps/form/src/components/cards/AboutSportPage/SportCard.tsx
+++ b/apps/form/src/components/cards/AboutSportPage/SportCard.tsx
@@ -97,7 +97,7 @@ export default function SportCard({
               <SportIcon imageUrl={imageUrl} />
               <Stack
                 direction="row"
-                sx={{ alignItems: "center", justifyContent: "center" }}
+                sx={{ alignItems: "center", justifyContent: "center", minWidth: 0, width: '100%', overflow: 'hidden' }}
               >
                 {hasTeam && (
                   <Box
@@ -120,8 +120,10 @@ export default function SportCard({
                   </Box>
                 )}
                 <Typography
+                  noWrap
                   sx={(theme) => ({
                     ...theme.typography.secondFont,
+                    minWidth: 0,
                   })}
                 >
                   {name}

--- a/apps/panel/components/dashboard/MatchResultPopup.tsx
+++ b/apps/panel/components/dashboard/MatchResultPopup.tsx
@@ -90,8 +90,9 @@ export const MatchResultPopup = ({ myTeamMatches }: Props) => {
             py: 2,
           }}
         >
-          <Box sx={{ flex: 1, textAlign: "center" }}>
+          <Box sx={{ flex: 1, textAlign: "center", minWidth: 0, overflow: 'hidden' }}>
             <Typography
+              noWrap
               fontSize="16px"
               fontWeight={600}
               color={
@@ -113,8 +114,9 @@ export const MatchResultPopup = ({ myTeamMatches }: Props) => {
               {score0} - {score1}
             </Typography>
           </Box>
-          <Box sx={{ flex: 1, textAlign: "center" }}>
+          <Box sx={{ flex: 1, textAlign: "center", minWidth: 0, overflow: 'hidden' }}>
             <Typography
+              noWrap
               fontSize="16px"
               fontWeight={600}
               color={

--- a/apps/panel/components/dashboard/Overview/index.tsx
+++ b/apps/panel/components/dashboard/Overview/index.tsx
@@ -90,8 +90,8 @@ export const Overview = (props: OverviewProps) => {
                                 <Typography fontSize={"14px"} sx={{color: theme.palette.text.primary}}>
                                     あなたの競技
                                 </Typography>
-                                <Typography fontSize={"14px"} fontWeight={"600"}
-                                            sx={{color: theme.palette.text.primary}}>
+                                <Typography noWrap fontSize={"14px"} fontWeight={"600"}
+                                            sx={{color: theme.palette.text.primary, width: '100%'}}>
                                     {props.mySport.name}
                                 </Typography>
                             </Stack>
@@ -159,7 +159,7 @@ export const Overview = (props: OverviewProps) => {
                                 <Typography sx={{fontSize: "14px", color: theme.palette.text.primary}}>
                                     チーム
                                 </Typography>
-                                <Typography sx={{fontSize: "18px", color: theme.palette.text.primary}}>
+                                <Typography noWrap sx={{fontSize: "18px", color: theme.palette.text.primary, width: '100%'}}>
                                     {props.myTeam.name}
                                 </Typography>
                             </Stack>
@@ -230,7 +230,7 @@ export const Overview = (props: OverviewProps) => {
                                                 >
                                                     <HiUser/>
                                                 </Avatar>
-                                                <Typography color={theme.palette.text.primary}>
+                                                <Typography noWrap color={theme.palette.text.primary} sx={{ minWidth: 0, flex: 1 }}>
                                                     {user.name}
                                                 </Typography>
                                             </Stack>

--- a/apps/panel/components/dashboard/SportsListElement.tsx
+++ b/apps/panel/components/dashboard/SportsListElement.tsx
@@ -30,17 +30,19 @@ export const SportsListElement = (props: SportsListElementProps) => {
                     justifyContent={"flex-start"}
                     alignItems={"center"}
                     spacing={2}
+                    sx={{ minWidth: 0, overflow: 'hidden' }}
                 >
                     <Avatar
                         alt={props.sport.name}
                         sx={{height: "2em", width: "2em",
                             backgroundColor: theme.palette.text.secondary,
+                            flexShrink: 0,
                         }}
                         src={props.sport.image?.url ?? undefined}
                     >
                         {!props.sport.image && <HiOutlineExclamationTriangle fontSize={"20px"}/>}
                     </Avatar>
-                    <Typography color={theme.palette.text.primary}>
+                    <Typography noWrap color={theme.palette.text.primary} sx={{ minWidth: 0 }}>
                         {props.sport.name}
                     </Typography>
                 </Stack>

--- a/apps/panel/components/dashboard/schedule/ScheduleContent.tsx
+++ b/apps/panel/components/dashboard/schedule/ScheduleContent.tsx
@@ -66,7 +66,7 @@ export const ScheduleContent = (props: ScheduleContentProps) => {
                         spacing={1}
                         justifyContent={"flex-start"}
                         alignItems={"center"}
-                        sx={{height: "60px", flexGrow: 1,}}
+                        sx={{height: "60px", flexGrow: 1, minWidth: 0, overflow: 'hidden'}}
                     >
                         <Box
                             sx={{
@@ -76,14 +76,15 @@ export const ScheduleContent = (props: ScheduleContentProps) => {
                                 backgroundColor: theme.palette.text.secondary,
                                 display: "flex",
                                 justifyContent: "center",
-                                alignItems: "center"
+                                alignItems: "center",
+                                flexShrink: 0,
                             }}
                         >
                             <Typography color={theme.palette.background.default} fontSize={"10px"} fontWeight={"600"}>
                                 VS
                             </Typography>
                         </Box>
-                        <Typography fontSize={"20px"} color={theme.palette.text.primary}>
+                        <Typography noWrap fontSize={"20px"} color={theme.palette.text.primary} sx={{ minWidth: 0 }}>
                             {opponentName}
                         </Typography>
                     </Stack>
@@ -117,7 +118,7 @@ export const ScheduleContent = (props: ScheduleContentProps) => {
                             <SvgIcon fontSize={"small"}>
                                 <HiMapPin color={theme.palette.text.secondary}/>
                             </SvgIcon>
-                            <Typography sx={{color: theme.palette.text.primary, fontSize: "14px"}}>
+                            <Typography noWrap sx={{color: theme.palette.text.primary, fontSize: "14px", minWidth: 0}}>
                                 {props.match.location?.name ?? "未登録"}
                             </Typography>
                         </Stack>

--- a/apps/panel/components/dashboard/schedule/judgeScheduleContent.tsx
+++ b/apps/panel/components/dashboard/schedule/judgeScheduleContent.tsx
@@ -162,7 +162,7 @@ export const ScheduleContent = (props: ScheduleContentProps) => {
                             <SvgIcon fontSize={"small"}>
                                 <HiMapPin color={theme.palette.text.secondary}/>
                             </SvgIcon>
-                            <Typography sx={{color: theme.palette.text.primary, fontSize: "14px"}}>
+                            <Typography noWrap sx={{color: theme.palette.text.primary, fontSize: "14px", minWidth: 0}}>
                                 {props.match.location?.name ?? "未登録"}
                             </Typography>
                         </Stack>

--- a/apps/panel/components/discover/DiscoverTeamContent.tsx
+++ b/apps/panel/components/discover/DiscoverTeamContent.tsx
@@ -51,12 +51,12 @@ export const DiscoverTeamContent = (props:DiscoverTeamContentProps) => {
                                 spacing={1}
                                 py={1}
                                 pl={2}
-                                sx={{flexGrow:1}}
+                                sx={{flexGrow:1, minWidth: 0, overflow: 'hidden'}}
                             >
                                 <Typography color={theme.palette.text.secondary} fontSize={"14px"}>
                                     チーム名
                                 </Typography>
-                                <Typography fontWeight={"bold"} color={theme.palette.text.primary}>
+                                <Typography fontWeight={"bold"} color={theme.palette.text.primary} noWrap sx={{ width: '100%' }}>
                                     {props.matchSet.team.name}
                                 </Typography>
                             </Stack>

--- a/apps/panel/components/discover/discoverUser.tsx
+++ b/apps/panel/components/discover/discoverUser.tsx
@@ -83,7 +83,7 @@ export const DiscoverUser = (props: DiscoverUserProps) => {
                     >
                         <HiUser/>
                     </Avatar>
-                    <Typography color={theme.palette.text.primary}>
+                    <Typography noWrap color={theme.palette.text.primary} sx={{ minWidth: 0, flex: 1 }}>
                         {props.user.name}
                     </Typography>
 
@@ -138,7 +138,7 @@ export const DiscoverUser = (props: DiscoverUserProps) => {
                                         >
                                             <HiUser/>
                                         </Avatar>
-                                        <Typography color={theme.palette.text.primary}>
+                                        <Typography noWrap color={theme.palette.text.primary} sx={{ minWidth: 0, flex: 1 }}>
                                             {props.user.name} さん
                                         </Typography>
                                     </Stack>
@@ -159,11 +159,11 @@ export const DiscoverUser = (props: DiscoverUserProps) => {
                                         {!userMatchSport?.image && <HiOutlineExclamationTriangle fontSize={"30px"}/>}
                                     </Avatar>
                                     <Stack>
-                                        <Typography fontSize={"14px"} sx={{color: theme.palette.text.primary}}>
+                                        <Typography noWrap fontSize={"14px"} sx={{color: theme.palette.text.primary}}>
                                             {props.user.name}の競技
                                         </Typography>
                                         {userMatchSports.map((sport) => (
-                                            <Typography fontSize={"14px"} fontWeight={"600"} key={sport.id}>
+                                            <Typography noWrap fontSize={"14px"} fontWeight={"600"} key={sport.id}>
                                                 {sport.name}
                                             </Typography>
                                         ))}

--- a/apps/panel/components/discover/userDetail.tsx
+++ b/apps/panel/components/discover/userDetail.tsx
@@ -172,7 +172,7 @@ export const UserDetail = (props: UserDetailProps) => {
                                         <Typography sx={{color: theme.palette.text.primary, fontSize: "20px", fontWeight: "bold"}}>
                                             {leftScore}
                                         </Typography>
-                                        <Typography fontSize={"20px"} color={theme.palette.text.primary}>
+                                        <Typography noWrap fontSize={"20px"} color={theme.palette.text.primary} sx={{ minWidth: 0 }}>
                                             {leftTeamName}
                                         </Typography>
                                     </Stack>
@@ -198,7 +198,7 @@ export const UserDetail = (props: UserDetailProps) => {
                                         alignItems={"center"}
                                         spacing={2}
                                     >
-                                        <Typography fontSize={"20px"} color={theme.palette.text.primary}>
+                                        <Typography noWrap fontSize={"20px"} color={theme.palette.text.primary} sx={{ minWidth: 0 }}>
                                             {rightTeamName}
                                         </Typography>
                                         <Typography sx={{color: theme.palette.text.primary, fontSize: "20px", fontWeight: "bold"}}>
@@ -273,6 +273,7 @@ export const UserDetail = (props: UserDetailProps) => {
                         </Card>
 
                         <Typography
+                            noWrap
                             color={theme.palette.text.primary}
                             textAlign={"center"}
                             pt={2}
@@ -297,7 +298,7 @@ export const UserDetail = (props: UserDetailProps) => {
                                                 >
                                                     <HiUser/>
                                                 </Avatar>
-                                                <Typography color={theme.palette.text.primary}>
+                                                <Typography noWrap color={theme.palette.text.primary} sx={{ minWidth: 0, flex: 1 }}>
                                                     {user.name}
                                                 </Typography>
                                             </Stack>
@@ -306,6 +307,7 @@ export const UserDetail = (props: UserDetailProps) => {
                                 );
                             })}
                         <Typography
+                            noWrap
                             color={theme.palette.text.primary}
                             textAlign={"center"}
                             pt={2}
@@ -330,7 +332,7 @@ export const UserDetail = (props: UserDetailProps) => {
                                                 >
                                                     <HiUser/>
                                                 </Avatar>
-                                                <Typography color={theme.palette.text.primary}>
+                                                <Typography noWrap color={theme.palette.text.primary} sx={{ minWidth: 0, flex: 1 }}>
                                                     {user.name}
                                                 </Typography>
                                             </Stack>

--- a/apps/panel/components/game/GameList/matchDetail.tsx
+++ b/apps/panel/components/game/GameList/matchDetail.tsx
@@ -184,7 +184,7 @@ export const MatchDetail = (props: MatchDetailProps) => {
                                     <Typography sx={{color: theme.palette.text.primary, fontSize: "20px", fontWeight: "bold"}}>
                                         {leftScore}
                                     </Typography>
-                                    <Typography fontSize={"20px"} color={theme.palette.text.primary}>
+                                    <Typography noWrap fontSize={"20px"} color={theme.palette.text.primary} sx={{ minWidth: 0 }}>
                                         {leftTeamName}
                                     </Typography>
                                 </Stack>
@@ -210,7 +210,7 @@ export const MatchDetail = (props: MatchDetailProps) => {
                                     alignItems={"center"}
                                     spacing={2}
                                 >
-                                    <Typography fontSize={"20px"} color={theme.palette.text.primary}>
+                                    <Typography noWrap fontSize={"20px"} color={theme.palette.text.primary} sx={{ minWidth: 0 }}>
                                         {rightTeamName}
                                     </Typography>
                                     <Typography sx={{color: theme.palette.text.primary, fontSize: "20px", fontWeight: "bold"}}>
@@ -285,6 +285,7 @@ export const MatchDetail = (props: MatchDetailProps) => {
                     </Card>
 
                     <Typography
+                        noWrap
                         color={theme.palette.text.primary}
                         textAlign={"center"}
                         pt={2}
@@ -309,7 +310,7 @@ export const MatchDetail = (props: MatchDetailProps) => {
                                             >
                                                 <HiUser/>
                                             </Avatar>
-                                            <Typography color={theme.palette.text.primary}>
+                                            <Typography noWrap color={theme.palette.text.primary} sx={{ minWidth: 0, flex: 1 }}>
                                                 {user.name}
                                             </Typography>
                                         </Stack>
@@ -318,6 +319,7 @@ export const MatchDetail = (props: MatchDetailProps) => {
                             );
                         })}
                     <Typography
+                        noWrap
                         color={theme.palette.text.primary}
                         textAlign={"center"}
                         pt={2}
@@ -342,7 +344,7 @@ export const MatchDetail = (props: MatchDetailProps) => {
                                             >
                                                 <HiUser/>
                                             </Avatar>
-                                            <Typography color={theme.palette.text.primary}>
+                                            <Typography noWrap color={theme.palette.text.primary} sx={{ minWidth: 0, flex: 1 }}>
                                                 {user.name}
                                             </Typography>
                                         </Stack>

--- a/apps/panel/components/game/RankList/LeagueRankList.tsx
+++ b/apps/panel/components/game/RankList/LeagueRankList.tsx
@@ -57,16 +57,20 @@ export const LeagueRankList = (props: LeagueRankListProps) => {
                             alignItems={"center"}
                             justifyContent={"start"}
                             m={2}
+                            sx={{ minWidth: 0, overflow: 'hidden' }}
                         >
                             <Typography
                                 fontSize={"30px"}
                                 color={theme.palette.text.secondary}
+                                sx={{ flexShrink: 0 }}
                             >
                                 #{props.myTeamRank}
                             </Typography>
                             <Typography
                                 fontSize={"20px"}
                                 color={theme.palette.text.primary}
+                                noWrap
+                                sx={{ minWidth: 0, flexGrow: 1 }}
                             >
                                 {props.myTeam?.name}
                             </Typography>

--- a/apps/panel/components/game/RankList/LeagueRankListCard.tsx
+++ b/apps/panel/components/game/RankList/LeagueRankListCard.tsx
@@ -23,7 +23,7 @@ export const LeagueRankListCard = (props: LeagueRankListCardProps) => {
 
     return (
         <>
-            <Box sx={{minWidth:"140px"}}>
+            <Box sx={{minWidth:"140px", maxWidth:"200px"}}>
                 <Button
                     disableElevation
                     color={"secondary"}
@@ -33,6 +33,7 @@ export const LeagueRankListCard = (props: LeagueRankListCardProps) => {
                         background:`linear-gradient(${theme.palette.secondary.main}, ${theme.palette.secondary.dark}80)`,
                         border: `1px solid ${theme.palette.secondary.dark}66`,
                         boxShadow: `0px 0px 5px ${theme.palette.primary.dark}33`,
+                        width: '100%',
                     }}
                 >
                     <Stack
@@ -42,6 +43,7 @@ export const LeagueRankListCard = (props: LeagueRankListCardProps) => {
                         alignItems={"start"}
                         mt={1}
                         mb={2}
+                        sx={{ minWidth: 0 }}
                     >
                         <Typography
                             fontSize={"30px"}
@@ -53,6 +55,8 @@ export const LeagueRankListCard = (props: LeagueRankListCardProps) => {
                             fontSize={"20px"}
                             color={theme.palette.text.primary}
                             mt={1}
+                            noWrap
+                            sx={{ width: '100%' }}
                         >
                             {props.teamName}
                         </Typography>

--- a/apps/panel/components/information/league/leagueCard.tsx
+++ b/apps/panel/components/information/league/leagueCard.tsx
@@ -41,9 +41,9 @@ export default function LeagueCard(props: LeagueCardProps) {
                         </Typography>
                     </Stack>
                 </Grid2>
-                <Grid2 size={{ xs: 4.5 }} display="flex" justifyContent="center" alignItems="center">
-                    <Stack direction="column" alignItems="center" justifyContent="center">
-                        <Typography variant="h4" component="div" textAlign="center">
+                <Grid2 size={{ xs: 4.5 }} display="flex" justifyContent="center" alignItems="center" sx={{ minWidth: 0, overflow: 'hidden' }}>
+                    <Stack direction="column" alignItems="center" justifyContent="center" sx={{ width: '100%', minWidth: 0 }}>
+                        <Typography variant="h4" component="div" textAlign="center" noWrap sx={{ width: '100%' }}>
                             {props.team ?? "未登録"}
                         </Typography>
                     </Stack>

--- a/apps/panel/components/information/league/top3LeagueCards.tsx
+++ b/apps/panel/components/information/league/top3LeagueCards.tsx
@@ -107,7 +107,7 @@ export default function Top3LeagueCards(props: Top3LeagueCardsProps) {
                             </Typography>
 
                         </Stack>
-                        <Typography variant="h3" component="div" textAlign="center">
+                        <Typography noWrap variant="h3" component="div" textAlign="center" sx={{ width: '100%' }}>
                             {results[1]?.teamName ?? "なし"}
                         </Typography>
 
@@ -151,7 +151,7 @@ export default function Top3LeagueCards(props: Top3LeagueCardsProps) {
                             </Typography>
 
                         </Stack>
-                        <Typography variant="h3" component="div" textAlign="center">
+                        <Typography noWrap variant="h3" component="div" textAlign="center" sx={{ width: '100%' }}>
                             {results[0]?.teamName ?? "なし"}
                         </Typography>
 
@@ -195,7 +195,7 @@ export default function Top3LeagueCards(props: Top3LeagueCardsProps) {
                             </Typography>
 
                         </Stack>
-                        <Typography variant="h3" component="div" textAlign="center">
+                        <Typography noWrap variant="h3" component="div" textAlign="center" sx={{ width: '100%' }}>
                             {results[2]?.teamName ?? "なし"}
                         </Typography>
 

--- a/apps/panel/components/information/match/matchCard.tsx
+++ b/apps/panel/components/information/match/matchCard.tsx
@@ -53,13 +53,13 @@ export default function MatchCard(props: MatchCardProps) {
 
                         <Grid2 container spacing={2.5} width="100%" height="100%" alignItems="center"
                                justifyContent="center" margin="0">
-                            <Grid2 size={{ xs: 2.5 }} display="flex" justifyContent="center">
-                                <Typography variant="subtitle1" component="div" textAlign="center">
+                            <Grid2 size={{ xs: 2.5 }} display="flex" justifyContent="center" sx={{ minWidth: 0, overflow: 'hidden' }}>
+                                <Typography variant="subtitle1" component="div" textAlign="center" noWrap sx={{ width: '100%' }}>
                                     {props.match.competition.name}
                                 </Typography>
                             </Grid2>
-                            <Grid2 size={{ xs: 2.5 }} display="flex" justifyContent="center">
-                                <Typography variant="h4" component="div" textAlign="center">
+                            <Grid2 size={{ xs: 2.5 }} display="flex" justifyContent="center" sx={{ minWidth: 0, overflow: 'hidden' }}>
+                                <Typography variant="h4" component="div" textAlign="center" noWrap sx={{ width: '100%' }}>
                                     {leftTeamName}
                                 </Typography>
                             </Grid2>
@@ -68,8 +68,8 @@ export default function MatchCard(props: MatchCardProps) {
                                     vs
                                 </Typography>
                             </Grid2>
-                            <Grid2 size={{ xs: 2.5 }} display="flex" justifyContent="center">
-                                <Typography variant="h4" component="div" textAlign="center">
+                            <Grid2 size={{ xs: 2.5 }} display="flex" justifyContent="center" sx={{ minWidth: 0, overflow: 'hidden' }}>
+                                <Typography variant="h4" component="div" textAlign="center" noWrap sx={{ width: '100%' }}>
                                     {rightTeamName}
                                 </Typography>
                             </Grid2>

--- a/apps/panel/components/layouts/navigation.tsx
+++ b/apps/panel/components/layouts/navigation.tsx
@@ -108,7 +108,7 @@ export const Navigation = () => {
                                     >
                                         <HiUser/>
                                     </Avatar>
-                                    <Typography sx={{color: theme.palette.text.secondary, fontSize: "16px"}}>
+                                    <Typography noWrap sx={{color: theme.palette.text.secondary, fontSize: "16px", minWidth: 0, flex: 1}}>
                                         {user?.name ?? "unknown"} さん
                                     </Typography>
                                 </Stack>

--- a/apps/panel/components/sports/sportsCard.tsx
+++ b/apps/panel/components/sports/sportsCard.tsx
@@ -31,7 +31,7 @@ export const SportCard: React.FC<SportCardProps> = ({img, children, link}) => {
                         src={img}
                     >
                     </Avatar>}
-                    <Typography fontSize={"inherit"} color={"text.primary"}>
+                    <Typography noWrap fontSize={"inherit"} color={"text.primary"} sx={{ width: '100%', textAlign: 'center' }}>
                         {children}
                     </Typography>
                 </Stack>


### PR DESCRIPTION
# やったこと

admin/panel/form の各コンポーネントで、チーム名・競技名・ユーザー名などの
動的テキストが長い場合に要素の幅が広がりレイアウトが崩れる問題を修正。

- admin: LIST_TABLE_SX / CARD_TABLE_SX を追加し tableLayout: fixed を適用、 BREADCRUMB_CURRENT_SX にオーバーフロー制御を追加（一括対応）
- panel: 各カード・ランキング・スケジュール・Discover系コンポーネントの Typography に noWrap と flex コンテナに minWidth: 0 を追加
- form: SportCard / TeamCard / ConfirmCard / SceneStatusCardLayout の 動的テキスト Typography にオーバーフロー制御を追加

