### PR TITLE
fix(ui): Flexbox/Grid内のテキスト省略が機能しないバグを修正

### DIFF
--- a/apps/admin/src/features/competitions/components/TournamentBracketView.tsx
+++ b/apps/admin/src/features/competitions/components/TournamentBracketView.tsx
@@ -237,7 +237,7 @@ function TeamRow({ label, score, isWinner, isLoser, isBottom, empty, seedNumber,
         />
       )}
       <Typography noWrap sx={{
-        fontSize: '13px', flex: 1,
+        fontSize: '13px', flex: 1, minWidth: 0,
         color: empty ? C.emptySeed : (isWinner ? C.headerText : C.bodyText),
         fontWeight: isWinner ? 700 : 400,
         fontStyle: empty ? 'italic' : 'normal',

--- a/apps/form/src/components/cards/AboutConfirmPage/ConfirmCard.tsx
+++ b/apps/form/src/components/cards/AboutConfirmPage/ConfirmCard.tsx
@@ -192,7 +192,7 @@ export default function ConfirmCard({
                       ?.slice()
                       .reverse()
                       .map((member, idx) => (
-                        <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }} key={`${row.teamId}-${member.name}-${idx}`}>
+                        <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }} key={`${row.teamId}-${member.name}-${idx}`} sx={{ minWidth: 0 }}>
                           <Card
                             sx={{
                               background: theme.palette.card.main,
@@ -205,6 +205,8 @@ export default function ConfirmCard({
                               alignItems: "center",
                               justifyContent: "center",
                               position: "relative",
+                              minWidth: 0,
+                              overflow: "hidden",
                             }}
                           >
                             {member.isExperienced && (

--- a/apps/form/src/components/cards/AboutConfirmPage/SceneStatusCardLayout.tsx
+++ b/apps/form/src/components/cards/AboutConfirmPage/SceneStatusCardLayout.tsx
@@ -135,6 +135,7 @@ export default function SceneStatusCardLayout({
                           <Grid
                             size={{ xs: 12, sm: 6, md: 4, lg: 3 }}
                             key={`${item.scenename}-${user}-${userIndex}`}
+                            sx={{ minWidth: 0 }}
                           >
                             <Card
                               sx={{
@@ -149,6 +150,8 @@ export default function SceneStatusCardLayout({
                                 display: "flex",
                                 alignItems: "center",
                                 justifyContent: "center",
+                                minWidth: 0,
+                                overflow: "hidden",
                               }}
                             >
                               <Typography

--- a/apps/form/src/features/TeamEdit.tsx
+++ b/apps/form/src/features/TeamEdit.tsx
@@ -149,7 +149,7 @@ export default function TeamEdit() {
                     </Box>
                   ) : (
                     selectedMember.map((student) => (
-                      <Box key={student.studentId} sx={{ p: "8px" }}>
+                      <Box key={student.studentId} sx={{ p: "8px", width: "100%", minWidth: 0 }}>
                         <MembersCard
                           studentname={student.studentName}
                           fixed={true}


### PR DESCRIPTION
# やったこと

minWidth: 0 または width: "100%" の欠落により、noWrap/textOverflow: ellipsis が 機能せずコンテンツ幅で要素が広がり重なって表示されていた問題を修正。

- form: TeamEdit の追加済みメンバーリスト Box に width/minWidth を追加
- form: SceneStatusCardLayout / ConfirmCard の Grid・Card に minWidth/overflow を追加
- admin: TournamentBracketView の Typography (flex:1) に minWidth: 0 を追加
