### PR TITLE
fix(form): fieldsetのmin-widthによるレイアウト崩れを修正

### DIFF
--- a/apps/form/src/features/TeamEdit.tsx
+++ b/apps/form/src/features/TeamEdit.tsx
@@ -100,6 +100,7 @@ export default function TeamEdit() {
                   borderStyle: "solid",
                   borderRadius: "10px",
                   width: "100%",
+                  minWidth: 0,
                   background: "none",
                   display: "flex",
                   flexDirection: "column",
@@ -123,6 +124,8 @@ export default function TeamEdit() {
                   direction="column"
                   flexWrap="nowrap"
                   sx={{
+                    width: "100%",
+                    minWidth: 0,
                     flexGrow: 1,
                     overflowY: "scroll",
                     overflowX: "hidden",


### PR DESCRIPTION
# やったこと

<fieldset>はブラウザデフォルトでmin-inline-size: min-contentが設定されるため、
width: 100%だけでは長いコンテンツに合わせて幅が広がりレイアウトが崩れていた。

- Card(fieldset)にminWidth: 0を追加してブラウザデフォルトを上書き
- 内側StackにもwidthとminWidth: 0を追加して幅制限を確実に伝播させる
