### PR TITLE
fix(loki): instance_addr を追加して empty ring エラーを修正

### DIFF
--- a/docker/loki/loki-config.yaml
+++ b/docker/loki/loki-config.yaml
@@ -14,6 +14,7 @@ server:
 
 # ─── 共通設定（ingesterとストレージの共有設定）────────────────────
 common:
+  instance_addr: 127.0.0.1
   path_prefix: /loki
   storage:
     filesystem:
@@ -21,6 +22,7 @@ common:
       rules_directory: /loki/rules
   replication_factor: 1
   ring:
+    instance_addr: 127.0.0.1
     kvstore:
       store: inmemory
 


### PR DESCRIPTION
# やったこと

Loki シングルノード構成で common ブロックに instance_addr が未設定だったため、 ingester がリングに自分を登録できず empty ring エラーが発生していた。
common および common.ring に instance_addr: 127.0.0.1 を追加して修正。

