### PR TITLE
fix(form): 経験者ボタンが反応しないバグを修正

### DIFF
--- a/apps/form/src/features/hooks/useTeamEdit.ts
+++ b/apps/form/src/features/hooks/useTeamEdit.ts
@@ -54,6 +54,7 @@ export function useTeamEdit() {
   );
   const { data: experienceData, loading: experienceLoading } = useGetSportExperienceQuery({
     variables: { sportId: sports },
+    fetchPolicy: "cache-and-network",
   });
 
   // Graph API でユーザー名を解決
@@ -75,7 +76,9 @@ export function useTeamEdit() {
     [msGraphUsers],
   );
 
-  const experiencedLimit = experienceData?.sport?.experiencedLimit ?? null;
+  const rawExperiencedLimit = experienceData?.sport?.experiencedLimit ?? null;
+  // 0 以下は未設定と同様に「制限なし」として扱う
+  const experiencedLimit = rawExperiencedLimit != null && rawExperiencedLimit > 0 ? rawExperiencedLimit : null;
 
   // 既存の経験者データで初期化（一度だけ）
   useEffect(() => {
@@ -328,6 +331,7 @@ export function useTeamEdit() {
           GetTeamDocument,
           "GetSceneSport",
           "GetAllTeamdata",
+          "GetSportExperience",
         ],
       });
       navigate(-1);

--- a/apps/form/src/features/teamEdit.gql.ts
+++ b/apps/form/src/features/teamEdit.gql.ts
@@ -123,6 +123,7 @@ export const DELETE_TEAM = gql`
 export const GET_SPORT_EXPERIENCE = gql`
   query GetSportExperience($sportId: ID!) {
     sport(id: $sportId) {
+      id
       experiencedLimit
     }
     sportExperiences(sportId: $sportId) {

--- a/apps/form/src/gql/__generated__/graphql.ts
+++ b/apps/form/src/gql/__generated__/graphql.ts
@@ -1548,7 +1548,7 @@ export type GetSportExperienceQueryVariables = Exact<{
 }>;
 
 
-export type GetSportExperienceQuery = { __typename?: 'Query', sport: { __typename?: 'Sport', experiencedLimit?: number | null }, sportExperiences: Array<{ __typename?: 'SportExperience', userId: string }> };
+export type GetSportExperienceQuery = { __typename?: 'Query', sport: { __typename?: 'Sport', id: string, experiencedLimit?: number | null }, sportExperiences: Array<{ __typename?: 'SportExperience', userId: string }> };
 
 export type AddSportExperiencesMutationVariables = Exact<{
   sportId: Scalars['ID']['input'];
@@ -2589,6 +2589,7 @@ export type DeleteTeamMutationOptions = Apollo.BaseMutationOptions<DeleteTeamMut
 export const GetSportExperienceDocument = gql`
     query GetSportExperience($sportId: ID!) {
   sport(id: $sportId) {
+    id
     experiencedLimit
   }
   sportExperiences(sportId: $sportId) {


### PR DESCRIPTION
# やったこと

- experiencedLimit=0 のとき最初から上限到達扱いになりボタンが無効化されていた問題を修正（0以下はnullと同様に「制限なし」として扱う）
- useGetSportExperienceQuery に fetchPolicy: cache-and-network を追加し常に最新の経験者データを取得するよう変更
- refetchQueries に GetSportExperience を追加し送信後にキャッシュが更新されるよう修正
- GET_SPORT_EXPERIENCE クエリに sport.id を追加してApolloキャッシュ正規化を改善


