### PR TITLE
feat(infra): nginx経由でGrafanaにアクセスできるよう設定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,6 +167,8 @@ services:
         condition: service_healthy
       form:
         condition: service_healthy
+      grafana:
+        condition: service_started
     ports:
       - "80:80"
       - "443:443"
@@ -237,6 +239,8 @@ services:
       GF_USERS_ALLOW_SIGN_UP: "false"
       # セキュリティ: Grafana を外部から直接アクセスさせる場合はドメインを設定
       GF_SERVER_DOMAIN: ${GRAFANA_DOMAIN:-localhost}
+      GF_SERVER_ROOT_URL: https://%(domain)s/grafana/
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
       # Discord Webhook URL（アラート通知用）
       DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL}
     volumes:
@@ -249,6 +253,7 @@ services:
         condition: service_healthy
     networks:
       - backend
+      - frontend
 
 networks:
   backend:

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -38,6 +38,9 @@ http {
     upstream form {
         server form:8080;
     }
+    upstream grafana {
+        server grafana:3000;
+    }
 
     # ─── HTTP → HTTPS redirect ───────────────────────
     server {
@@ -109,6 +112,16 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # ── Grafana (/grafana/) ──────────────────────
+        location /grafana/ {
+            proxy_pass         http://grafana/;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
         }
 
         # ── Panel SPA (/ catch-all) ──────────────────


### PR DESCRIPTION
# やったこと

- nginx に grafana upstream と /grafana/ location を追加
- Grafana にサブパス設定（GF_SERVER_ROOT_URL, GF_SERVER_SERVE_FROM_SUB_PATH）を追加
- Grafana を frontend ネットワークに追加して nginx から到達できるよう変更
- nginx の depends_on に grafana を追加

https://<ドメイン>/grafana/ でアクセス可能になる

