### PR TITLE
fix(infra): Grafanaへのリバースプロキシのリダイレクトループを修正

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -116,7 +116,7 @@ http {
 
         # ── Grafana (/grafana/) ──────────────────────
         location /grafana/ {
-            proxy_pass         http://grafana/;
+            proxy_pass         http://grafana;
             proxy_http_version 1.1;
             proxy_set_header   Host              $host;
             proxy_set_header   X-Real-IP         $remote_addr;


### PR DESCRIPTION
# やったこと

sproxy_pass の trailing slash を除去することでパスの書き換えを防ぐ。
trailing slash ありだと /grafana/ を除去して転送するため、
Grafana のサブパス設定とミスマッチが起きてリダイレクトループが発生していた。

