### PR TITLE
fix(infra): GrafanaサブパスプロキシのリダイレクトループをToo Many Redirectsを修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,7 +240,7 @@ services:
       # nginx リバースプロキシ経由でサブパス /grafana/ に配置する設定
       # GRAFANA_DOMAIN に実際のドメインを設定すること（例: example.com）
       GF_SERVER_DOMAIN: ${GRAFANA_DOMAIN:-localhost}
-      GF_SERVER_ROOT_URL: "%(protocol)s://%(domain)s/grafana/"
+      GF_SERVER_ROOT_URL: "https://%(domain)s/grafana/"
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
       # Discord Webhook URL（アラート通知用）
       DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL}

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -116,7 +116,7 @@ http {
 
         # ── Grafana (/grafana/) ──────────────────────
         location /grafana/ {
-            proxy_pass         http://grafana/;
+            proxy_pass         http://grafana;
             proxy_http_version 1.1;
             proxy_set_header   Host              $http_host;
             proxy_set_header   X-Real-IP         $remote_addr;


### PR DESCRIPTION
# やったこと

- nginx: proxy_pass末尾スラッシュを削除し/grafana/プレフィックスをGrafanaにそのまま転送
- docker-compose: GF_SERVER_ROOT_URLのprotocolをhttps固定に変更


