### PR TITLE
fix(infra): GrafanaのERR_UNSAFE_REDIRECTを根本修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,7 +225,7 @@ services:
 
   # ─── Grafana (可視化・分析ダッシュボード) ──────────────
   grafana:
-    image: grafana/grafana:11.0.0
+    image: grafana/grafana:11.6.0
     restart: unless-stopped
     # Grafana はコンテナ内で UID 472 (grafana ユーザー) で動作する。
     # DATA_DIR/grafana ディレクトリを事前に作成しておく必要がある。
@@ -242,6 +242,12 @@ services:
       GF_SERVER_DOMAIN: ${GRAFANA_DOMAIN:-localhost}
       GF_SERVER_ROOT_URL: "https://%(domain)s/grafana/"
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+      # HTTPS 環境での Cookie セキュリティ（Secure フラグ必須）
+      GF_SECURITY_COOKIE_SECURE: "true"
+      # Grafana 11 の CSRF 保護: POST リクエストの Origin を許可するドメインを明示。
+      # GRAFANA_DOMAIN が未設定だと root_url との Origin 不一致でリダイレクトが
+      # 発生し ERR_UNSAFE_REDIRECT につながるため、信頼済みオリジンを明示する。
+      GF_SECURITY_CSRF_TRUSTED_ORIGINS: "https://${GRAFANA_DOMAIN:-localhost}"
       # Discord Webhook URL（アラート通知用）
       DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL}
     volumes:

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -28,11 +28,15 @@ STORAGE_WEBHOOK_SECRET=your-webhook-secret
 
 # ─── Grafana ──────────────────────────────────────────
 # Grafana 管理者パスワード（初回起動時に設定される）
-# http://<server-ip>:3000 でアクセス可能
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=your-secure-grafana-password
-# 外部からアクセスする場合はドメイン名を設定（例: grafana.your-domain.com）
-GRAFANA_DOMAIN=localhost
+# 【必須】nginx のリバースプロキシ経由でアクセスするドメイン名を設定する。
+# 未設定（localhost のまま）の場合:
+#   - GF_SERVER_ROOT_URL が https://localhost/grafana/ になる
+#   - Grafana 11 の CSRF 保護で Origin 不一致が起きリダイレクトが発生
+#   - リダイレクト先が http:// になり ERR_UNSAFE_REDIRECT になる
+# 例: GRAFANA_DOMAIN=sportsday.h.nc-toyama.ac.jp
+GRAFANA_DOMAIN=your-domain.example.com
 # Discord Incoming Webhook URL（アラート通知用）
 # チャンネル設定 → 連携サービス → ウェブフック → 新しいウェブフック → URLをコピー
 DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/your-webhook-id/your-webhook-token

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -149,7 +149,11 @@ http {
             proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Proto $scheme;
             proxy_set_header   Connection        "";
-            proxy_redirect     http:// https://;
+            # Grafana が内部ホスト名（grafana:3000 等）で http:// リダイレクトを
+            # 生成した場合でも、ブラウザが受け取る URL を正しい https://$http_host に変換する。
+            # "http:// https://" では内部ホスト名がそのまま残り ERR_UNSAFE_REDIRECT になるため
+            # regex で任意のホスト部分を $http_host に置き換える。
+            proxy_redirect     ~^http://[^/]+(/.*)$ https://$http_host$1;
         }
 
         # ── Panel SPA (/ catch-all) ──────────────────


### PR DESCRIPTION
# やったこと

- Grafana 11.0.0 → 11.6.0 にアップグレード（11.0系のサブパスCSRFバグを修正済み）
- GF_SECURITY_CSRF_TRUSTED_ORIGINS を追加（Grafana 11のCSRF保護でOrigin不一致によるリダイレクトを防止）
- GF_SECURITY_COOKIE_SECURE=true を追加（HTTPS環境でのCookieセキュリティ強化）
- nginx proxy_redirect をregex版に変更（内部ホスト名grafana:3000等でのリダイレクトも正しくhttps://$http_hostに変換）
- docker/.env.exampleのGRAFANA_DOMAIN説明を強化（未設定時の影響を明記）

