### PR TITLE
fix(infra): grafana-lokiexplore-appプラグインをサブパス環境でのエラー回避のため無効化

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -250,6 +250,10 @@ services:
       GF_SECURITY_CSRF_TRUSTED_ORIGINS: "https://${GRAFANA_DOMAIN:-localhost}"
       # Discord Webhook URL（アラート通知用）
       DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL}
+      # grafana-lokiexplore-app はサブパス環境で SystemJS の react/jsx-runtime
+      # 解決に失敗し毎回エラーを起こすため無効化する。
+      # Loki データソース・ダッシュボードパネルへの影響はない。
+      GF_PLUGINS_DISABLE_PLUGINS: "grafana-lokiexplore-app"
     volumes:
       - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro
       - ${DATA_DIR:-./data}/grafana:/var/lib/grafana


### PR DESCRIPTION
# やったこと

サブパス(/grafana/)運用時にSystemJSがreact/jsx-runtimeを
/grafana/react/jsx-runtimeに誤解決し404エラーが毎回発生する問題を修正。 Lokiデータソース・ダッシュボードへの影響なし。

