### PR TITLE
fix(admin): エントリー追加ダイアログのチーム一覧を競技のスポーツ・シーンでフィルタリング

### DIFF
--- a/apps/admin/src/features/competitions/api.ts
+++ b/apps/admin/src/features/competitions/api.ts
@@ -174,6 +174,20 @@ export const GET_ADMIN_SPORTS_WITH_SCENES = gql`
   }
 `
 
+export const GET_ADMIN_SPORT_SCENE_ENTRIES = gql`
+  query GetAdminSportSceneEntries($sceneId: ID!) {
+    scene(id: $sceneId) {
+      id
+      sportScenes {
+        sport { id }
+        entries {
+          team { id }
+        }
+      }
+    }
+  }
+`
+
 export const CREATE_ADMIN_COMPETITION = gql`
   mutation CreateAdminCompetition($input: CreateCompetitionInput!) {
     createCompetition(input: $input) {

--- a/apps/admin/src/features/competitions/components/AddEntryDialog.tsx
+++ b/apps/admin/src/features/competitions/components/AddEntryDialog.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Checkbox,
   Chip,
+  CircularProgress,
   Collapse,
   Dialog,
   DialogContent,
@@ -24,13 +25,14 @@ type Props = {
   open: boolean
   leagueName: string
   sportId?: string
+  sceneId?: string
   existingTeamNames?: string[]
   onClose: () => void
   onAdd: (selectedIds: string[]) => void
 }
 
-export function AddEntryDialog({ open, leagueName, sportId = '', existingTeamNames = [], onClose, onAdd }: Props) {
-  const { teams } = useAddEntryTeams(sportId)
+export function AddEntryDialog({ open, leagueName, sportId = '', sceneId = '', existingTeamNames = [], onClose, onAdd }: Props) {
+  const { teams, loading } = useAddEntryTeams(sportId, sceneId)
   const existingSet = useMemo(() => new Set(existingTeamNames), [existingTeamNames])
   const availableTeams = useMemo(() => teams.filter(t => !existingSet.has(t.name)), [teams, existingSet])
   const { selected, allSelected, expandedTeamId, toggle, toggleAll, toggleExpand, handleAdd } = useAddEntryDialog(availableTeams.map(t => t.id), onAdd)
@@ -143,7 +145,11 @@ export function AddEntryDialog({ open, leagueName, sportId = '', existingTeamNam
             pr: 0.5,
           }}
         >
-          {filteredTeams.length === 0 ? (
+          {loading ? (
+            <Box sx={{ py: 6, textAlign: 'center' }}>
+              <CircularProgress size={24} sx={{ color: '#5B6DC6' }} />
+            </Box>
+          ) : filteredTeams.length === 0 ? (
             <Box sx={{ py: 6, textAlign: 'center' }}>
               <Typography sx={{ fontSize: '14px', color: '#666' }}>
                 {search ? '該当するチームがありません' : '追加できるチームがありません'}

--- a/apps/admin/src/features/competitions/components/LeagueDetailPage.tsx
+++ b/apps/admin/src/features/competitions/components/LeagueDetailPage.tsx
@@ -475,6 +475,7 @@ export function LeagueDetailPage({ leagueId, leagueName, competitionId, competit
         open={addDialogOpen}
         leagueName={leagueName}
         sportId={form.sportId}
+        sceneId={form.sceneId}
         existingTeamNames={entries.map(e => e.teamName)}
         onClose={handleCloseAddDialog}
         onAdd={(selectedIds) => {

--- a/apps/admin/src/features/competitions/components/TournamentDetailPage.tsx
+++ b/apps/admin/src/features/competitions/components/TournamentDetailPage.tsx
@@ -860,6 +860,7 @@ export function TournamentDetailPage({
         open={addDialogOpen}
         leagueName={data.name}
         sportId={form.sportId}
+        sceneId={form.sceneId}
         existingTeamNames={entries.map(e => e.teamName)}
         onClose={handleCloseAddDialog}
         onAdd={handleAddEntries}

--- a/apps/admin/src/features/competitions/hooks/useAddEntryTeams.ts
+++ b/apps/admin/src/features/competitions/hooks/useAddEntryTeams.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useGetAdminTeamsQuery, useGetAdminUsersQuery } from '@/gql/__generated__/graphql'
+import { useGetAdminTeamsQuery, useGetAdminUsersQuery, useGetAdminSportSceneEntriesQuery } from '@/gql/__generated__/graphql'
 import { useMsGraphUsers } from '@/hooks/useMsGraphUsers'
 
 export type EntryTeamMember = {
@@ -15,9 +15,13 @@ export type EntryTeam = {
   experiencedCount: number
 }
 
-export function useAddEntryTeams(sportId: string) {
+export function useAddEntryTeams(sportId: string, sceneId: string) {
   const { data: teamsData } = useGetAdminTeamsQuery()
   const { data: usersData } = useGetAdminUsersQuery()
+  const { data: sceneData, loading: sceneLoading } = useGetAdminSportSceneEntriesQuery({
+    variables: { sceneId },
+    skip: !sceneId,
+  })
 
   const allUserMsIds = useMemo(() => {
     return (teamsData?.teams ?? [])
@@ -29,29 +33,46 @@ export function useAddEntryTeams(sportId: string) {
   const { msGraphUsers } = useMsGraphUsers(allUserMsIds)
 
   const teams: EntryTeam[] = useMemo(() => {
+    // sportId・sceneIdが両方揃っている場合のみ、SportEntryでフィルタリング
+    const registeredTeamIds = new Set<string>()
+    if (sportId && sceneId && sceneData?.scene) {
+      for (const sportScene of sceneData.scene.sportScenes) {
+        if (sportScene.sport.id === sportId) {
+          for (const entry of sportScene.entries) {
+            registeredTeamIds.add(entry.team.id)
+          }
+        }
+      }
+    }
+    const shouldFilter = sportId && sceneId && sceneData?.scene != null
+
     const experiencedUserIds = new Set(
       (usersData?.allSportExperiences ?? [])
         .filter(e => sportId && e.sportId === sportId)
         .map(e => e.userId),
     )
 
-    return (teamsData?.teams ?? []).map(t => {
-      const members: EntryTeamMember[] = (t.users ?? []).map(u => {
-        const msUser = u.identify?.microsoftUserId ? msGraphUsers.get(u.identify.microsoftUserId) : undefined
+    return (teamsData?.teams ?? [])
+      .filter(t => !shouldFilter || registeredTeamIds.has(t.id))
+      .map(t => {
+        const members: EntryTeamMember[] = (t.users ?? []).map(u => {
+          const msUser = u.identify?.microsoftUserId ? msGraphUsers.get(u.identify.microsoftUserId) : undefined
+          return {
+            id: u.id,
+            name: msUser?.displayName ?? u.name ?? '',
+            isExperienced: sportId ? experiencedUserIds.has(u.id) : false,
+          }
+        })
         return {
-          id: u.id,
-          name: msUser?.displayName ?? u.name ?? '',
-          isExperienced: sportId ? experiencedUserIds.has(u.id) : false,
+          id: t.id,
+          name: t.name,
+          members,
+          experiencedCount: members.filter(m => m.isExperienced).length,
         }
       })
-      return {
-        id: t.id,
-        name: t.name,
-        members,
-        experiencedCount: members.filter(m => m.isExperienced).length,
-      }
-    })
-  }, [teamsData, usersData, sportId, msGraphUsers])
+  }, [teamsData, usersData, sceneData, sportId, sceneId, msGraphUsers])
 
-  return { teams }
+  const loading = !!sceneId && sceneLoading && sceneData == null
+
+  return { teams, loading }
 }

--- a/apps/admin/src/gql/__generated__/graphql.ts
+++ b/apps/admin/src/gql/__generated__/graphql.ts
@@ -1536,6 +1536,13 @@ export type GetAdminSportsWithScenesQueryVariables = Exact<{ [key: string]: neve
 
 export type GetAdminSportsWithScenesQuery = { __typename?: 'Query', sports: Array<{ __typename?: 'Sport', id: string, name: string, scene?: Array<{ __typename?: 'SportScene', id: string, scene: { __typename?: 'Scene', id: string, name: string } }> | null }> };
 
+export type GetAdminSportSceneEntriesQueryVariables = Exact<{
+  sceneId: Scalars['ID']['input'];
+}>;
+
+
+export type GetAdminSportSceneEntriesQuery = { __typename?: 'Query', scene: { __typename?: 'Scene', id: string, sportScenes: Array<{ __typename?: 'SportScene', sport: { __typename?: 'Sport', id: string }, entries: Array<{ __typename?: 'SportEntry', team: { __typename?: 'Team', id: string } }> }> } };
+
 export type CreateAdminCompetitionMutationVariables = Exact<{
   input: CreateCompetitionInput;
 }>;
@@ -3080,6 +3087,56 @@ export type GetAdminSportsWithScenesQueryHookResult = ReturnType<typeof useGetAd
 export type GetAdminSportsWithScenesLazyQueryHookResult = ReturnType<typeof useGetAdminSportsWithScenesLazyQuery>;
 export type GetAdminSportsWithScenesSuspenseQueryHookResult = ReturnType<typeof useGetAdminSportsWithScenesSuspenseQuery>;
 export type GetAdminSportsWithScenesQueryResult = Apollo.QueryResult<GetAdminSportsWithScenesQuery, GetAdminSportsWithScenesQueryVariables>;
+export const GetAdminSportSceneEntriesDocument = gql`
+    query GetAdminSportSceneEntries($sceneId: ID!) {
+  scene(id: $sceneId) {
+    id
+    sportScenes {
+      sport {
+        id
+      }
+      entries {
+        team {
+          id
+        }
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetAdminSportSceneEntriesQuery__
+ *
+ * To run a query within a React component, call `useGetAdminSportSceneEntriesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAdminSportSceneEntriesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAdminSportSceneEntriesQuery({
+ *   variables: {
+ *      sceneId: // value for 'sceneId'
+ *   },
+ * });
+ */
+export function useGetAdminSportSceneEntriesQuery(baseOptions: Apollo.QueryHookOptions<GetAdminSportSceneEntriesQuery, GetAdminSportSceneEntriesQueryVariables> & ({ variables: GetAdminSportSceneEntriesQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetAdminSportSceneEntriesQuery, GetAdminSportSceneEntriesQueryVariables>(GetAdminSportSceneEntriesDocument, options);
+      }
+export function useGetAdminSportSceneEntriesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetAdminSportSceneEntriesQuery, GetAdminSportSceneEntriesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetAdminSportSceneEntriesQuery, GetAdminSportSceneEntriesQueryVariables>(GetAdminSportSceneEntriesDocument, options);
+        }
+export function useGetAdminSportSceneEntriesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetAdminSportSceneEntriesQuery, GetAdminSportSceneEntriesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetAdminSportSceneEntriesQuery, GetAdminSportSceneEntriesQueryVariables>(GetAdminSportSceneEntriesDocument, options);
+        }
+export type GetAdminSportSceneEntriesQueryHookResult = ReturnType<typeof useGetAdminSportSceneEntriesQuery>;
+export type GetAdminSportSceneEntriesLazyQueryHookResult = ReturnType<typeof useGetAdminSportSceneEntriesLazyQuery>;
+export type GetAdminSportSceneEntriesSuspenseQueryHookResult = ReturnType<typeof useGetAdminSportSceneEntriesSuspenseQuery>;
+export type GetAdminSportSceneEntriesQueryResult = Apollo.QueryResult<GetAdminSportSceneEntriesQuery, GetAdminSportSceneEntriesQueryVariables>;
 export const CreateAdminCompetitionDocument = gql`
     mutation CreateAdminCompetition($input: CreateCompetitionInput!) {
   createCompetition(input: $input) {


### PR DESCRIPTION
- GET_ADMIN_SPORT_SCENE_ENTRIES クエリを追加し SportEntry からチームIDを取得
- useAddEntryTeams に sceneId を追加して SportScene.entries でフィルタリング
- AddEntryDialog に sceneId props を追加、ローディング中はスピナーを表示
- LeagueDetailPage・TournamentDetailPage から form.sceneId を渡すよう修正
