### PR TITLE
fix: PDFメンバー表の名前空白バグ・認証サイレントリニュー競合を修正

### DIFF
--- a/apps/admin/src/components/ApolloProvider.tsx
+++ b/apps/admin/src/components/ApolloProvider.tsx
@@ -10,17 +10,19 @@ import { setContext } from "@apollo/client/link/context";
 import { userManager } from "@/lib/userManager";
 import { showErrorToast, showWarningToast, suppressNextError } from "@/lib/toast";
 
+// 複数クエリが同時にexpiredを検知してsigninSilent()を並行実行するのを防ぐ
+let renewingPromise: Promise<import('oidc-client-ts').User | null> | null = null
+
 const authLink = setContext(async (_, { headers }) => {
     let user = await userManager.getUser()
 
-    // トークンが期限切れの場合、サイレントリニューを試みる
     if (user?.expired) {
-        try {
-            user = await userManager.signinSilent()
-        } catch {
-            // サイレントリニュー失敗時はトークンなしで送信（401が返りerrorLinkで処理）
-            user = null
+        if (!renewingPromise) {
+            renewingPromise = userManager.signinSilent()
+                .catch(() => null)
+                .finally(() => { renewingPromise = null })
         }
+        user = await renewingPromise
     }
 
     return {

--- a/apps/admin/src/features/competitions/hooks/useCompetitionPdfData.ts
+++ b/apps/admin/src/features/competitions/hooks/useCompetitionPdfData.ts
@@ -120,7 +120,7 @@ export function useCompetitionPdfData(sportId: string, sceneId: string, skip = f
             id: t.id,
             name: t.name,
             groupName: t.group.name,
-            members: t.users.map((u) => ({ id: u.id, name: '' })),
+            members: t.users.map((u) => ({ id: u.id, name: u.name })),
           }
         })
         .filter((t): t is PdfTeam => t !== null)

--- a/apps/form/src/components/ApolloProvider.tsx
+++ b/apps/form/src/components/ApolloProvider.tsx
@@ -8,16 +8,19 @@ import {
 import { setContext } from "@apollo/client/link/context";
 import { userManager } from "@/lib/userManager";
 
+// 複数クエリが同時にexpiredを検知してsigninSilent()を並行実行するのを防ぐ
+let renewingPromise: Promise<import('oidc-client-ts').User | null> | null = null
+
 const authLink = setContext(async (_, { headers }) => {
   let user = await userManager.getUser();
 
-  // トークンが期限切れの場合、サイレントリニューを試みる
   if (user?.expired) {
-    try {
-      user = await userManager.signinSilent();
-    } catch {
-      user = null;
+    if (!renewingPromise) {
+      renewingPromise = userManager.signinSilent()
+        .catch(() => null)
+        .finally(() => { renewingPromise = null })
     }
+    user = await renewingPromise
   }
 
   return {

--- a/apps/panel/src/components/ApolloProvider.tsx
+++ b/apps/panel/src/components/ApolloProvider.tsx
@@ -27,16 +27,19 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
     }
 });
 
+// 複数クエリが同時にexpiredを検知してsigninSilent()を並行実行するのを防ぐ
+let renewingPromise: Promise<import('oidc-client-ts').User | null> | null = null
+
 const authLink = setContext(async (_, { headers }) => {
     let user = await userManager.getUser()
 
-    // トークンが期限切れの場合、サイレントリニューを試みる
     if (user?.expired) {
-        try {
-            user = await userManager.signinSilent()
-        } catch {
-            user = null
+        if (!renewingPromise) {
+            renewingPromise = userManager.signinSilent()
+                .catch(() => null)
+                .finally(() => { renewingPromise = null })
         }
+        user = await renewingPromise
     }
 
     return {


### PR DESCRIPTION
## Summary

- **PDFメンバー表が空になるバグを修正** (`apps/admin`): `useCompetitionPdfData.ts` でPDF用データ構築時にメンバー名を `''` に設定していた箇所を `u.name` に修正。GraphQLでは名前を正しく取得できていたが、詰め替え時に意図せず消去されていた
- **認証サイレントリニューの並行実行競合を修正** (`admin` / `panel` / `form`): 複数のGraphQLクエリが同時にトークン期限切れを検知した際にそれぞれ独立して `signinSilent()` を呼び出し、`token_missing` / `token_invalid` が大量発生する問題を修正。`renewingPromise` でシングルトン化し、進行中のリニューを全クエリで共有するよう変更

## Test plan

- [ ] 競技一覧からPDF出力 → メンバー表にメンバー名が表示されることを確認
- [ ] ページ初期表示時に複数クエリが並行実行されても `token_missing` / `token_invalid` が量産されないことをログで確認
- [ ] モバイルChromeでログイン → 正常にページが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)