### PR TITLE
fix(admin): PDFメンバー名をMicrosoft Graph displayNameから取得

### DIFF
--- a/apps/admin/src/features/competitions/hooks/useCompetitionPdfData.ts
+++ b/apps/admin/src/features/competitions/hooks/useCompetitionPdfData.ts
@@ -5,6 +5,7 @@ import {
   useGetAdminTeamsQuery,
   useGetAdminMatchesQuery,
 } from '@/gql/__generated__/graphql'
+import { useMsGraphUsers } from '@/hooks/useMsGraphUsers'
 
 // ─── リーグ色 ─────────────────────────────────────────
 export const LEAGUE_COLORS = [
@@ -65,7 +66,18 @@ export function useCompetitionPdfData(sportId: string, sceneId: string, skip = f
   const { data: teamsData, loading: teamsLoading } = useGetAdminTeamsQuery({ skip, fetchPolicy: 'network-only' })
   const { data: matchesData, loading: matchesLoading } = useGetAdminMatchesQuery({ skip, fetchPolicy: 'network-only' })
 
-  const loading = compsLoading || leaguesLoading || teamsLoading || matchesLoading
+  // チームメンバーの Microsoft Graph displayName を取得（DB の name は null のケースがあるため）
+  const microsoftUserIds = useMemo(
+    () =>
+      (teamsData?.teams ?? [])
+        .flatMap((t) => t.users)
+        .map((u) => u.identify?.microsoftUserId)
+        .filter((id): id is string => !!id),
+    [teamsData],
+  )
+  const { msGraphUsers, loading: msGraphLoading } = useMsGraphUsers(microsoftUserIds)
+
+  const loading = compsLoading || leaguesLoading || teamsLoading || matchesLoading || msGraphLoading
 
   return useMemo(() => {
     if (!compsData || !leaguesData || !teamsData || !matchesData) {
@@ -120,7 +132,12 @@ export function useCompetitionPdfData(sportId: string, sceneId: string, skip = f
             id: t.id,
             name: t.name,
             groupName: t.group.name,
-            members: t.users.map((u) => ({ id: u.id, name: u.name ?? '' })),
+            members: t.users.map((u) => ({
+              id: u.id,
+              name: u.identify?.microsoftUserId
+                ? (msGraphUsers.get(u.identify.microsoftUserId)?.displayName ?? u.name ?? '')
+                : (u.name ?? ''),
+            })),
           }
         })
         .filter((t): t is PdfTeam => t !== null)
@@ -169,7 +186,7 @@ export function useCompetitionPdfData(sportId: string, sceneId: string, skip = f
     const locations = [...locationSet].sort()
 
     return { sportName, sceneName, leagues, schedule: allMatches, locations, loading }
-  }, [compsData, leaguesData, teamsData, matchesData, sportId, sceneId, loading])
+  }, [compsData, leaguesData, teamsData, matchesData, msGraphUsers, sportId, sceneId, loading])
 }
 
 function formatTime(time: string): string {


### PR DESCRIPTION
## 問題

PDFのメンバー名が空白のまま表示される。

**根本原因**: DB の `User.name` は NULL が許容されており、実際の氏名は Microsoft Graph API の `displayName` に格納されている。ユーザー一覧タブは `useMsGraphUsers()` で Graph API を呼び出して `displayName` を取得・表示しているが、PDF データフックはこれを呼び出していなかった。

## 修正内容

`useCompetitionPdfData` に `useMsGraphUsers` を組み込み、ユーザー一覧タブと同じ優先順位でメンバー名を解決するよう変更。

```
displayName (Microsoft Graph) > User.name (DB) > ''
```

- `GET_ADMIN_TEAMS` は元々 `identify { microsoftUserId }` を含んでいるため、クエリ変更は不要
- `skip=true` 時は `microsoftUserIds` が空配列になり Graph API は呼ばれない
- Graph API ロード中は `loading` フラグが立ちPDFの表示を待機する

## 影響範囲

- `apps/admin/src/features/competitions/hooks/useCompetitionPdfData.ts` のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)