### PR TITLE
fix(admin): ラウンドロビン再生成時に競技の時間設定を反映する

### DIFF
--- a/apps/admin/src/features/matches/hooks/useLeagueRegenerate.ts
+++ b/apps/admin/src/features/matches/hooks/useLeagueRegenerate.ts
@@ -1,14 +1,21 @@
 import { useState } from 'react'
-import { useGenerateAdminRoundRobinMutation } from '@/gql/__generated__/graphql'
+import { useGenerateAdminRoundRobinMutation, useGetAdminCompetitionQuery } from '@/gql/__generated__/graphql'
 import { showApiErrorToast } from '@/lib/toast'
 
-export function useLeagueRegenerate(_competitionId: string, leagueId: string) {
+export function useLeagueRegenerate(competitionId: string, leagueId: string) {
   const [isOpen, setIsOpen] = useState(false)
   const [selectedLocation, setSelectedLocation] = useState('')
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
   const [mutationError, setMutationError] = useState<Error | null>(null)
 
   const [generateRoundRobin] = useGenerateAdminRoundRobinMutation()
+
+  // 競技に保存済みの時間設定を取得し、再生成時に反映する
+  const { data: compData } = useGetAdminCompetitionQuery({
+    variables: { id: competitionId },
+    skip: !competitionId,
+    fetchPolicy: 'cache-and-network',
+  })
 
   const openOverlay = () => setIsOpen(true)
 
@@ -23,13 +30,20 @@ export function useLeagueRegenerate(_competitionId: string, leagueId: string) {
 
   const confirmSave = async () => {
     try {
+      const comp = compData?.competition
+      const startTime = comp?.startTime
+        ? new Date(comp.startTime).toISOString()
+        : new Date().toISOString()
+      const matchDuration = comp?.matchDuration ?? 15
+      const breakDuration = comp?.breakDuration ?? 5
+
       await generateRoundRobin({
         variables: {
           id: leagueId,
           input: {
-            startTime: new Date().toISOString(),
-            matchDuration: 15,
-            breakDuration: 5,
+            startTime,
+            matchDuration,
+            breakDuration,
             locationId: selectedLocation || undefined,
           },
         },


### PR DESCRIPTION
## 問題

各大会の編集画面で試合時間設定（開始時刻・試合時間・休憩時間）を設定しても、各試合に反映されない。

**根本原因**: 試合一覧画面の「ラウンドロビン再生成」ボタンを押したとき、`useLeagueRegenerate.ts` が `generateRoundRobin` を呼ぶ際に時間設定がハードコードされていた。

```typescript
// 修正前（ハードコード）
startTime: new Date().toISOString(),  // 現在時刻
matchDuration: 15,                    // 固定15分
breakDuration: 5,                     // 固定5分
```

これにより、競技編集画面で設定した値が再生成のたびに上書きされ、常に「現在時刻・15分・5分」でリセットされていた。

## 修正内容

`useGetAdminCompetitionQuery` で競技の保存済み設定を取得し、再生成時にその値を使用するよう変更。

```typescript
// 修正後（競技の保存済み設定を使用）
const startTime = comp?.startTime ? new Date(comp.startTime).toISOString() : new Date().toISOString()
const matchDuration = comp?.matchDuration ?? 15
const breakDuration = comp?.breakDuration ?? 5
```

未設定時は従来のフォールバック値（現在時刻・15分・5分）を使用。場所の選択は引き続きダイアログで上書き可能。

## 影響範囲

- `apps/admin/src/features/matches/hooks/useLeagueRegenerate.ts` のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)