### PR TITLE
fix(admin): applyDefaults で TimeManual を無視して全試合に時間を適用する

### DIFF
--- a/api/service/competition.go
+++ b/api/service/competition.go
@@ -1313,29 +1313,19 @@ func (s *Competition) ApplyDefaults(ctx context.Context, id string, input *model
 			return matches[i].ID < matches[j].ID
 		})
 
-		// 4. 手動変更を基準点として後続試合の時間をずらすロジック（startTime指定時のみ）
+		// 4. 全試合に対して startTime + index * interval で時間を適用（startTime指定時のみ）
 		interval := time.Duration(input.MatchDuration+input.BreakDuration) * time.Minute
-		anchor := startTime
-		autoIndex := 0
 
 		// デフォルト場所の設定
 		locationID := pkggorm.ToNullString(input.LocationID)
 
-		for _, m := range matches {
+		for i, m := range matches {
 			needsSave := false
 
 			// 時間の適用（startTime が指定された場合のみ）
 			if startTimeValid {
-				if m.TimeManual {
-					// 手動設定: 時間は変更せず、新たな基準点にする
-					anchor = m.Time.Add(interval)
-					autoIndex = 0
-				} else {
-					// 自動設定: anchor + autoIndex * interval
-					m.Time = anchor.Add(time.Duration(autoIndex) * interval)
-					needsSave = true
-					autoIndex++
-				}
+				m.Time = startTime.Add(time.Duration(i) * interval)
+				needsSave = true
 			}
 
 			// 場所の適用: 手動設定でない試合のみ


### PR DESCRIPTION
## Summary

- 大会編集画面で開始時刻・試合時間・休憩時間を保存しても試合の時間が更新されないバグを修正
- 原因: `ApplyDefaults` 関数内で `TimeManual=true` の試合がスキップされ、時間が上書きされなかった
- 手動設定フラグによる保護ロジックを廃止し、全試合を `startTime + index × interval` でシンプルに上書きする実装に変更

## Changes

- `api/service/competition.go` — `ApplyDefaults` の時間適用ロジックを簡略化
  - `TimeManual` チェックを削除
  - `anchor` / `autoIndex` 変数を廃止
  - 全試合を ULID順（生成順）で `startTime + i * interval` に設定

## Test plan

- [ ] 大会編集画面で開始時刻・試合時間・休憩時間を設定して保存する
- [ ] 全試合の時間が設定値に従って更新されることを確認する
- [ ] 個別に試合時間を手動編集した試合も含めて全て上書きされることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)