### PR TITLE
feat(admin): チーム編集画面にスポーツエントリー管理とクラスフィルタを追加

### DIFF
--- a/apps/admin/src/features/teams/api.ts
+++ b/apps/admin/src/features/teams/api.ts
@@ -16,7 +16,7 @@ export const GET_ADMIN_TEAM = gql`
     team(id: $id) {
       id
       name
-      group { id name }
+      group { id name users { id } }
       users { id name email identify { microsoftUserId } }
     }
   }
@@ -64,6 +64,43 @@ export const GET_ADMIN_GROUPS = gql`
     groups {
       id
       name
+    }
+  }
+`
+
+export const GET_ADMIN_SPORT_SCENES_FOR_TEAM = gql`
+  query GetAdminSportScenesForTeam {
+    sports {
+      id
+      name
+      scene {
+        id
+        scene { id name }
+        entries {
+          id
+          team { id }
+        }
+      }
+    }
+  }
+`
+
+export const ADD_TEAM_SPORT_ENTRY = gql`
+  mutation AddTeamSportEntry($sportSceneId: ID!, $teamId: ID!) {
+    addSportEntries(id: $sportSceneId, input: { teamIds: [$teamId] }) {
+      id
+      entries {
+        id
+        team { id }
+      }
+    }
+  }
+`
+
+export const DELETE_TEAM_SPORT_ENTRY = gql`
+  mutation DeleteTeamSportEntry($entryId: ID!) {
+    deleteSportEntry(id: $entryId) {
+      id
     }
   }
 `

--- a/apps/admin/src/features/teams/components/AddMemberDialog.tsx
+++ b/apps/admin/src/features/teams/components/AddMemberDialog.tsx
@@ -11,40 +11,19 @@ import {
   TableHead,
   TableRow,
 } from '@mui/material'
-import { useState, useMemo } from 'react'
-import { useGetAdminUsersQuery } from '@/gql/__generated__/graphql'
-import { useMsGraphUsers } from '@/hooks/useMsGraphUsers'
+import { useState } from 'react'
 import { LIST_TABLE_HEAD_SX, LIST_TABLE_CELL_SX, SAVE_BUTTON_SX } from '@/styles/commonSx'
+import type { SelectableUser } from '../types'
 
 type Props = {
   open: boolean
   onClose: () => void
   onAdd: (selectedIds: string[]) => void
+  users: SelectableUser[]
 }
 
-export function AddMemberDialog({ open, onClose, onAdd }: Props) {
+export function AddMemberDialog({ open, onClose, onAdd, users }: Props) {
   const [selectedIds, setSelectedIds] = useState<string[]>([])
-  const { data } = useGetAdminUsersQuery({ skip: !open })
-
-  const microsoftUserIds = useMemo(
-    () =>
-      (data?.users ?? [])
-        .map((u) => u.identify?.microsoftUserId)
-        .filter((id): id is string => !!id),
-    [data],
-  )
-  const { msGraphUsers } = useMsGraphUsers(microsoftUserIds)
-
-  const users = (data?.users ?? []).map(u => {
-    const msUser = u.identify?.microsoftUserId
-      ? msGraphUsers.get(u.identify.microsoftUserId)
-      : undefined
-    return {
-      id: u.id,
-      userName: msUser?.displayName ?? u.name ?? '',
-      email: msUser?.mail ?? u.email ?? '',
-    }
-  })
 
   const toggle = (id: string) => {
     setSelectedIds((prev) =>

--- a/apps/admin/src/features/teams/components/SportEntrySection.tsx
+++ b/apps/admin/src/features/teams/components/SportEntrySection.tsx
@@ -1,0 +1,82 @@
+import {
+  Box,
+  Card,
+  CardContent,
+  Checkbox,
+  CircularProgress,
+  Divider,
+  Typography,
+} from '@mui/material'
+import {
+  CARD_GRADIENT,
+  CARD_TABLE_CELL_SX,
+} from '@/styles/commonSx'
+import type { SportGroup } from '../types'
+
+type Props = {
+  sportGroups: SportGroup[]
+  onToggle: (sportSceneId: string, entryId: string | null) => void
+  loading?: boolean
+}
+
+export function SportEntrySection({ sportGroups, onToggle, loading }: Props) {
+  return (
+    <Card elevation={0} sx={{ background: CARD_GRADIENT }}>
+      <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+        <Typography sx={{ fontSize: '16px', fontWeight: 600, color: '#2F3C8C', mb: 2 }}>
+          スポーツエントリー
+        </Typography>
+
+        {loading ? (
+          <Box sx={{ py: 3, textAlign: 'center' }}>
+            <CircularProgress size={24} sx={{ color: '#5B6DC6' }} />
+          </Box>
+        ) : sportGroups.length === 0 ? (
+          <Typography sx={{ fontSize: '13px', color: '#2F3C8C', opacity: 0.5 }}>
+            登録可能なスポーツシーンがありません
+          </Typography>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            {sportGroups.map((sg, idx) => (
+              <Box key={sg.sportId}>
+                {idx > 0 && <Divider sx={{ mb: 1.5, borderColor: 'rgba(47, 60, 140, 0.15)' }} />}
+                <Typography sx={{ fontSize: '13px', fontWeight: 600, color: '#2F3C8C', mb: 0.5 }}>
+                  {sg.sportName}
+                </Typography>
+                {sg.scenes.map(scene => (
+                  <Box
+                    key={scene.sportSceneId}
+                    onClick={() => onToggle(scene.sportSceneId, scene.entryId)}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      px: 0.5,
+                      py: 0.25,
+                      borderRadius: 1,
+                      cursor: 'pointer',
+                      '&:hover': { backgroundColor: 'rgba(91, 109, 198, 0.08)' },
+                    }}
+                  >
+                    <Checkbox
+                      checked={scene.isRegistered}
+                      size="small"
+                      sx={{
+                        p: 0.25,
+                        color: '#AAAAAA',
+                        '&.Mui-checked': { color: '#5B6DC6' },
+                      }}
+                    />
+                    <Typography sx={{ ...CARD_TABLE_CELL_SX, fontSize: '13px' }}>
+                      {scene.sceneName}
+                    </Typography>
+                  </Box>
+                ))}
+              </Box>
+            ))}
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/src/features/teams/components/TeamDetailPage.tsx
+++ b/apps/admin/src/features/teams/components/TeamDetailPage.tsx
@@ -22,6 +22,7 @@ import { useTeamDetail } from '../hooks/useTeamDetail'
 import { useUnsavedWarning } from '@/hooks/useUnsavedWarning'
 import { showToast } from '@/lib/toast'
 import { AddMemberDialog } from './AddMemberDialog'
+import { SportEntrySection } from './SportEntrySection'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { SceneSelect } from '@/components/ui/SceneSelect'
 import {
@@ -61,6 +62,10 @@ export function TeamDetailPage({ teamId, onBack }: Props) {
     handleCloseDeleteDialog,
     dirty,
     teamName,
+    selectableUsers,
+    sportGroups,
+    sportScenesLoading,
+    handleToggleSportEntry,
   } = useTeamDetail(teamId)
 
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -158,6 +163,13 @@ export function TeamDetailPage({ teamId, onBack }: Props) {
         </CardContent>
       </Card>
 
+      {/* スポーツエントリーカード */}
+      <SportEntrySection
+        sportGroups={sportGroups}
+        onToggle={handleToggleSportEntry}
+        loading={sportScenesLoading}
+      />
+
       {/* メンバーカード */}
       <Card elevation={0} sx={{ background: CARD_GRADIENT }}>
         <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
@@ -208,6 +220,7 @@ export function TeamDetailPage({ teamId, onBack }: Props) {
         open={dialogOpen}
         onClose={handleCloseDialog}
         onAdd={handleAddMembers}
+        users={selectableUsers}
       />
 
       <ConfirmDialog

--- a/apps/admin/src/features/teams/hooks/useTeamDetail.ts
+++ b/apps/admin/src/features/teams/hooks/useTeamDetail.ts
@@ -6,12 +6,16 @@ import {
   useDeleteAdminTeamMutation,
   useUpdateAdminTeamUsersMutation,
   useGetAdminGroupsQuery,
+  useGetAdminSportScenesForTeamQuery,
+  useAddTeamSportEntryMutation,
+  useDeleteTeamSportEntryMutation,
   GetAdminTeamsDocument,
   GetAdminTeamDocument,
+  GetAdminSportScenesForTeamDocument,
 } from '@/gql/__generated__/graphql'
 import { useMsGraphUsers } from '@/hooks/useMsGraphUsers'
 import { showApiErrorToast } from '@/lib/toast'
-import type { TeamMember, SelectableUser } from '../types'
+import type { TeamMember, SelectableUser, SportGroup } from '../types'
 
 export function useTeamDetail(teamId: string) {
   const { data, loading, error } = useGetAdminTeamQuery({
@@ -21,10 +25,12 @@ export function useTeamDetail(teamId: string) {
   })
   const { data: usersData } = useGetAdminUsersQuery({ fetchPolicy: 'cache-and-network' })
   const { data: groupsData } = useGetAdminGroupsQuery({ fetchPolicy: 'cache-and-network' })
+  const { data: sportScenesData, loading: sportScenesLoading } = useGetAdminSportScenesForTeamQuery({
+    fetchPolicy: 'cache-and-network',
+  })
 
   const team = data?.team
 
-  // ユーザーID → microsoftUserId のマップを作成
   const msIdMap = useMemo(() => {
     const map = new Map<string, string>()
     for (const u of usersData?.users ?? []) {
@@ -35,13 +41,9 @@ export function useTeamDetail(teamId: string) {
     return map
   }, [usersData])
 
-  const allMsIds = useMemo(
-    () => [...msIdMap.values()],
-    [msIdMap],
-  )
+  const allMsIds = useMemo(() => [...msIdMap.values()], [msIdMap])
   const { msGraphUsers } = useMsGraphUsers(allMsIds)
 
-  // サーバー値 + 編集差分パターン
   const serverName = team?.name ?? ''
   const serverGroupId = team?.group?.id ?? ''
 
@@ -73,6 +75,8 @@ export function useTeamDetail(teamId: string) {
   const [updateTeam] = useUpdateAdminTeamMutation()
   const [deleteTeam] = useDeleteAdminTeamMutation()
   const [updateTeamUsers] = useUpdateAdminTeamUsersMutation()
+  const [addSportEntry] = useAddTeamSportEntryMutation()
+  const [deleteSportEntry] = useDeleteTeamSportEntryMutation()
 
   const handleOpenDialog = () => setDialogOpen(true)
   const handleCloseDialog = () => setDialogOpen(false)
@@ -154,18 +158,70 @@ export function useTeamDetail(teamId: string) {
     }
   }
 
-  // 追加可能なユーザー（現チームメンバー以外）
-  const currentMemberIds = new Set((team?.users ?? []).map(u => u.id))
-  const selectableUsers: SelectableUser[] = (usersData?.users ?? [])
-    .filter(u => !currentMemberIds.has(u.id))
-    .map(u => {
-      const msId = u.identify?.microsoftUserId
-      const msUser = msId ? msGraphUsers.get(msId) : undefined
-      return {
-        id: u.id,
-        userName: msUser?.displayName ?? u.name ?? '',
+  const handleToggleSportEntry = async (sportSceneId: string, entryId: string | null) => {
+    try {
+      if (entryId) {
+        await deleteSportEntry({
+          variables: { entryId },
+          refetchQueries: [{ query: GetAdminSportScenesForTeamDocument }],
+        })
+      } else {
+        await addSportEntry({
+          variables: { sportSceneId, teamId },
+          refetchQueries: [{ query: GetAdminSportScenesForTeamDocument }],
+        })
       }
-    })
+    } catch (e) {
+      showApiErrorToast(e)
+    }
+  }
+
+  // グループに所属するユーザーIDセット（メンバー追加フィルタ用）
+  const groupUserIds = useMemo(
+    () => new Set((team?.group?.users ?? []).map(u => u.id)),
+    [team],
+  )
+
+  const currentMemberIds = new Set((team?.users ?? []).map(u => u.id))
+
+  // チームのクラスに所属し、かつまだメンバーでないユーザーのみ表示
+  const selectableUsers: SelectableUser[] = useMemo(() => {
+    const allUsers = usersData?.users ?? []
+    const shouldFilterByGroup = groupUserIds.size > 0
+    return allUsers
+      .filter(u => !currentMemberIds.has(u.id) && (!shouldFilterByGroup || groupUserIds.has(u.id)))
+      .map(u => {
+        const msId = u.identify?.microsoftUserId
+        const msUser = msId ? msGraphUsers.get(msId) : undefined
+        return {
+          id: u.id,
+          userName: msUser?.displayName ?? u.name ?? '',
+          email: msUser?.mail ?? u.email ?? '',
+        }
+      })
+  // currentMemberIdsはrender毎に変わるのでteam?.usersで依存
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [usersData, team?.users, team?.group?.users, groupUserIds, msGraphUsers])
+
+  // スポーツエントリーグループ（スポーツ別・シーン別にまとめたもの）
+  const sportGroups: SportGroup[] = useMemo(() => {
+    const sports = sportScenesData?.sports ?? []
+    return sports
+      .map(sport => {
+        const scenes = (sport.scene ?? []).map(ss => {
+          const entry = ss.entries.find(e => e.team.id === teamId)
+          return {
+            sportSceneId: ss.id,
+            sceneId: ss.scene.id,
+            sceneName: ss.scene.name,
+            entryId: entry?.id ?? null,
+            isRegistered: !!entry,
+          }
+        })
+        return { sportId: sport.id, sportName: sport.name, scenes }
+      })
+      .filter(sg => sg.scenes.length > 0)
+  }, [sportScenesData, teamId])
 
   return {
     name,
@@ -187,6 +243,9 @@ export function useTeamDetail(teamId: string) {
     dirty,
     teamName: team?.name ?? '',
     selectableUsers,
+    sportGroups,
+    sportScenesLoading,
+    handleToggleSportEntry,
     loading,
     error: error ?? null,
     mutationError,

--- a/apps/admin/src/features/teams/types.ts
+++ b/apps/admin/src/features/teams/types.ts
@@ -12,4 +12,19 @@ export type TeamMember = {
 export type SelectableUser = {
   id: string
   userName: string
+  email: string
+}
+
+export type SportSceneRow = {
+  sportSceneId: string
+  sceneId: string
+  sceneName: string
+  entryId: string | null
+  isRegistered: boolean
+}
+
+export type SportGroup = {
+  sportId: string
+  sportName: string
+  scenes: SportSceneRow[]
 }

--- a/apps/admin/src/gql/__generated__/graphql.ts
+++ b/apps/admin/src/gql/__generated__/graphql.ts
@@ -2069,7 +2069,7 @@ export type GetAdminTeamQueryVariables = Exact<{
 }>;
 
 
-export type GetAdminTeamQuery = { __typename?: 'Query', team: { __typename?: 'Team', id: string, name: string, group: { __typename?: 'Group', id: string, name: string }, users: Array<{ __typename?: 'User', id: string, name?: string | null, email?: string | null, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } };
+export type GetAdminTeamQuery = { __typename?: 'Query', team: { __typename?: 'Team', id: string, name: string, group: { __typename?: 'Group', id: string, name: string, users: Array<{ __typename?: 'User', id: string }> }, users: Array<{ __typename?: 'User', id: string, name?: string | null, email?: string | null, identify: { __typename?: 'UserIdentify', microsoftUserId?: string | null } }> } };
 
 export type CreateAdminTeamMutationVariables = Exact<{
   input: CreateTeamInput;
@@ -2105,6 +2105,26 @@ export type GetAdminGroupsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type GetAdminGroupsQuery = { __typename?: 'Query', groups: Array<{ __typename?: 'Group', id: string, name: string }> };
+
+export type GetAdminSportScenesForTeamQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetAdminSportScenesForTeamQuery = { __typename?: 'Query', sports: Array<{ __typename?: 'Sport', id: string, name: string, scene?: Array<{ __typename?: 'SportScene', id: string, scene: { __typename?: 'Scene', id: string, name: string }, entries: Array<{ __typename?: 'SportEntry', id: string, team: { __typename?: 'Team', id: string } }> }> | null }> };
+
+export type AddTeamSportEntryMutationVariables = Exact<{
+  sportSceneId: Scalars['ID']['input'];
+  teamId: Scalars['ID']['input'];
+}>;
+
+
+export type AddTeamSportEntryMutation = { __typename?: 'Mutation', addSportEntries: { __typename?: 'SportScene', id: string, entries: Array<{ __typename?: 'SportEntry', id: string, team: { __typename?: 'Team', id: string } }> } };
+
+export type DeleteTeamSportEntryMutationVariables = Exact<{
+  entryId: Scalars['ID']['input'];
+}>;
+
+
+export type DeleteTeamSportEntryMutation = { __typename?: 'Mutation', deleteSportEntry: { __typename?: 'SportEntry', id: string } };
 
 export type GetAdminUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -6087,6 +6107,9 @@ export const GetAdminTeamDocument = gql`
     group {
       id
       name
+      users {
+        id
+      }
     }
     users {
       id
@@ -6324,6 +6347,132 @@ export type GetAdminGroupsQueryHookResult = ReturnType<typeof useGetAdminGroupsQ
 export type GetAdminGroupsLazyQueryHookResult = ReturnType<typeof useGetAdminGroupsLazyQuery>;
 export type GetAdminGroupsSuspenseQueryHookResult = ReturnType<typeof useGetAdminGroupsSuspenseQuery>;
 export type GetAdminGroupsQueryResult = Apollo.QueryResult<GetAdminGroupsQuery, GetAdminGroupsQueryVariables>;
+export const GetAdminSportScenesForTeamDocument = gql`
+    query GetAdminSportScenesForTeam {
+  sports {
+    id
+    name
+    scene {
+      id
+      scene {
+        id
+        name
+      }
+      entries {
+        id
+        team {
+          id
+        }
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetAdminSportScenesForTeamQuery__
+ *
+ * To run a query within a React component, call `useGetAdminSportScenesForTeamQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAdminSportScenesForTeamQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAdminSportScenesForTeamQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetAdminSportScenesForTeamQuery(baseOptions?: Apollo.QueryHookOptions<GetAdminSportScenesForTeamQuery, GetAdminSportScenesForTeamQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetAdminSportScenesForTeamQuery, GetAdminSportScenesForTeamQueryVariables>(GetAdminSportScenesForTeamDocument, options);
+      }
+export function useGetAdminSportScenesForTeamLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetAdminSportScenesForTeamQuery, GetAdminSportScenesForTeamQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetAdminSportScenesForTeamQuery, GetAdminSportScenesForTeamQueryVariables>(GetAdminSportScenesForTeamDocument, options);
+        }
+export function useGetAdminSportScenesForTeamSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetAdminSportScenesForTeamQuery, GetAdminSportScenesForTeamQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetAdminSportScenesForTeamQuery, GetAdminSportScenesForTeamQueryVariables>(GetAdminSportScenesForTeamDocument, options);
+        }
+export type GetAdminSportScenesForTeamQueryHookResult = ReturnType<typeof useGetAdminSportScenesForTeamQuery>;
+export type GetAdminSportScenesForTeamLazyQueryHookResult = ReturnType<typeof useGetAdminSportScenesForTeamLazyQuery>;
+export type GetAdminSportScenesForTeamSuspenseQueryHookResult = ReturnType<typeof useGetAdminSportScenesForTeamSuspenseQuery>;
+export type GetAdminSportScenesForTeamQueryResult = Apollo.QueryResult<GetAdminSportScenesForTeamQuery, GetAdminSportScenesForTeamQueryVariables>;
+export const AddTeamSportEntryDocument = gql`
+    mutation AddTeamSportEntry($sportSceneId: ID!, $teamId: ID!) {
+  addSportEntries(id: $sportSceneId, input: {teamIds: [$teamId]}) {
+    id
+    entries {
+      id
+      team {
+        id
+      }
+    }
+  }
+}
+    `;
+export type AddTeamSportEntryMutationFn = Apollo.MutationFunction<AddTeamSportEntryMutation, AddTeamSportEntryMutationVariables>;
+
+/**
+ * __useAddTeamSportEntryMutation__
+ *
+ * To run a mutation, you first call `useAddTeamSportEntryMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddTeamSportEntryMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addTeamSportEntryMutation, { data, loading, error }] = useAddTeamSportEntryMutation({
+ *   variables: {
+ *      sportSceneId: // value for 'sportSceneId'
+ *      teamId: // value for 'teamId'
+ *   },
+ * });
+ */
+export function useAddTeamSportEntryMutation(baseOptions?: Apollo.MutationHookOptions<AddTeamSportEntryMutation, AddTeamSportEntryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AddTeamSportEntryMutation, AddTeamSportEntryMutationVariables>(AddTeamSportEntryDocument, options);
+      }
+export type AddTeamSportEntryMutationHookResult = ReturnType<typeof useAddTeamSportEntryMutation>;
+export type AddTeamSportEntryMutationResult = Apollo.MutationResult<AddTeamSportEntryMutation>;
+export type AddTeamSportEntryMutationOptions = Apollo.BaseMutationOptions<AddTeamSportEntryMutation, AddTeamSportEntryMutationVariables>;
+export const DeleteTeamSportEntryDocument = gql`
+    mutation DeleteTeamSportEntry($entryId: ID!) {
+  deleteSportEntry(id: $entryId) {
+    id
+  }
+}
+    `;
+export type DeleteTeamSportEntryMutationFn = Apollo.MutationFunction<DeleteTeamSportEntryMutation, DeleteTeamSportEntryMutationVariables>;
+
+/**
+ * __useDeleteTeamSportEntryMutation__
+ *
+ * To run a mutation, you first call `useDeleteTeamSportEntryMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteTeamSportEntryMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteTeamSportEntryMutation, { data, loading, error }] = useDeleteTeamSportEntryMutation({
+ *   variables: {
+ *      entryId: // value for 'entryId'
+ *   },
+ * });
+ */
+export function useDeleteTeamSportEntryMutation(baseOptions?: Apollo.MutationHookOptions<DeleteTeamSportEntryMutation, DeleteTeamSportEntryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteTeamSportEntryMutation, DeleteTeamSportEntryMutationVariables>(DeleteTeamSportEntryDocument, options);
+      }
+export type DeleteTeamSportEntryMutationHookResult = ReturnType<typeof useDeleteTeamSportEntryMutation>;
+export type DeleteTeamSportEntryMutationResult = Apollo.MutationResult<DeleteTeamSportEntryMutation>;
+export type DeleteTeamSportEntryMutationOptions = Apollo.BaseMutationOptions<DeleteTeamSportEntryMutation, DeleteTeamSportEntryMutationVariables>;
 export const GetAdminUsersDocument = gql`
     query GetAdminUsers {
   users {


### PR DESCRIPTION
## Summary

- **スポーツエントリー管理**: チーム詳細画面にスポーツエントリーセクションを追加。スポーツ×シーンの組み合わせをチェックボックスで即時登録/解除できるようにした。これにより新規チームを大会エントリーの候補として表示させられる（`addSportEntries` / `deleteSportEntry` ミューテーション）
- **クラスフィルタ**: メンバー追加ダイアログでチームのクラス（group）に所属するユーザーのみ表示するよう変更。ダイアログ内の独自フェッチを廃止し、フック側でフィルタ済みリストを渡す設計に統一した

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `features/teams/api.ts` | `GET_ADMIN_TEAM` にグループユーザーを追加、スポーツエントリー用クエリ/ミューテーション3件追加 |
| `features/teams/types.ts` | `SelectableUser` に `email` 追加、`SportSceneRow` / `SportGroup` 型を追加 |
| `features/teams/hooks/useTeamDetail.ts` | スポーツエントリー管理ロジック・グループフィルタ追加 |
| `features/teams/components/SportEntrySection.tsx` | 新規作成：スポーツエントリー管理UI |
| `features/teams/components/AddMemberDialog.tsx` | `users` propsで受け取る設計に変更（内部フェッチ廃止） |
| `features/teams/components/TeamDetailPage.tsx` | `SportEntrySection` 追加、`selectableUsers` をダイアログに渡す |
| `src/gql/__generated__/graphql.ts` | codegen 再生成 |

## Test plan

- [ ] チームを新規作成し、スポーツエントリーセクションでシーンをチェックすると大会エントリーダイアログに表示されることを確認
- [ ] スポーツエントリーのチェックを外すと大会エントリーダイアログから除外されることを確認
- [ ] メンバー追加ダイアログでチームのクラスに所属するユーザーのみ表示されることを確認
- [ ] クラス未設定チームでメンバー追加ダイアログを開いた場合は全ユーザーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)