### PR TITLE
fix(admin): 自動進出ルールで同一進出先を複数順位に設定可能にする

### DIFF
--- a/apps/admin/src/features/competitions/components/ProgressionRulesEditor.tsx
+++ b/apps/admin/src/features/competitions/components/ProgressionRulesEditor.tsx
@@ -110,11 +110,6 @@ export function ProgressionRulesEditor({
                   {Array.from({ length: rankCount }, (_, i) => minRank + i).map(rank => {
                     const rule = rules.find(r => r.rank === rank)
                     const selectedTarget = allTargets.find(t => t.id === rule?.targetId)
-                    const usedTargetIds = new Set(
-                      rules
-                        .filter(r => r.rank !== rank && r.targetId)
-                        .map(r => r.targetId),
-                    )
                     const hasBoth = availableTargets.leagues.length > 0 && availableTargets.tournaments.length > 0
                     return (
                       <Box
@@ -198,7 +193,6 @@ export function ProgressionRulesEditor({
                                   <MenuItem
                                     key={target.id}
                                     value={target.id}
-                                    disabled={usedTargetIds.has(target.id)}
                                     onClick={(e) => {
                                       if (isSelected) {
                                         e.preventDefault()
@@ -241,7 +235,6 @@ export function ProgressionRulesEditor({
                                   <MenuItem
                                     key={target.id}
                                     value={target.id}
-                                    disabled={usedTargetIds.has(target.id)}
                                     onClick={(e) => {
                                       if (isSelected) {
                                         e.preventDefault()


### PR DESCRIPTION
## Summary

- `ProgressionRulesEditor` で `usedTargetIds` によって他の順位で使用済みの進出先を `disabled` にしていた制限を撤廃
- バックエンド (`CreatePromotionRuleInput`) および実行ロジック (`useExecuteProgression`) は既に同一 `targetCompetition` への複数ルール（1位・2位が同じトーナメントへ進出など）を正しく処理していたため、フロントエンドの UI 制限を除去するだけで解決

## Test plan

- [ ] リーグ詳細の自動進出設定で、1位と2位に同じトーナメントを選択できることを確認
- [ ] 自動進出を実行したとき、両チームが正しく同一進出先にエントリーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)