### PR TITLE
fix(team): メンバー削除ボタンが失敗する問題を修正

### DIFF
--- a/api/repository/team_sql.go
+++ b/api/repository/team_sql.go
@@ -64,6 +64,9 @@ func (r team) List(ctx context.Context, db *gorm.DB) ([]*db_model.Team, error) {
 }
 
 func (r team) AddTeamUsers(ctx context.Context, db *gorm.DB, teamId string, userIds []string) ([]*db_model.TeamUser, error) {
+	if len(userIds) == 0 {
+		return []*db_model.TeamUser{}, nil
+	}
 	entries := make([]*db_model.TeamUser, 0, len(userIds))
 	for _, uid := range userIds {
 		entries = append(entries, &db_model.TeamUser{
@@ -79,6 +82,9 @@ func (r team) AddTeamUsers(ctx context.Context, db *gorm.DB, teamId string, user
 }
 
 func (r team) DeleteTeamUsers(ctx context.Context, db *gorm.DB, teamId string, userIds []string) ([]*db_model.TeamUser, error) {
+	if len(userIds) == 0 {
+		return []*db_model.TeamUser{}, nil
+	}
 	var teamUsers []*db_model.TeamUser
 	if err := db.WithContext(ctx).Where("team_id = ? AND user_id IN (?)", teamId, userIds).Find(&teamUsers).Error; err != nil {
 		return nil, errors.Wrap(err)


### PR DESCRIPTION
## Summary

- `AddTeamUsers` / `DeleteTeamUsers` に空スライスガードを追加
- `removeUserIds` のみ渡した場合（追加なし・削除のみ）、`AddTeamUsers` が空スライスで `db.Create` を呼び `empty slice found` エラーが発生し、削除処理に到達できなかった
- 両メソッドの先頭で `len(userIds) == 0` をチェックし即早期リターンするよう修正

## Root Cause

`UpdateTeamUsers` リゾルバーは `addUserIds` と `removeUserIds` を別々に処理するが、`addUserIds` が nil でも `AddTeamUsers` を無条件で呼び出していた。GORM の `Create` は空スライスを渡すとエラーを返すため、削除処理が一切実行されなかった。

## Test plan

- [ ] チーム詳細画面でメンバーの削除ボタンを押して、メンバーが正常に削除されることを確認
- [ ] メンバー追加も引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)