### PR TITLE
feat(admin): PDFエクスポートのフォントサイズを3倍に拡大

### DIFF
--- a/apps/admin/src/features/competitions/lib/pdfConstants.ts
+++ b/apps/admin/src/features/competitions/lib/pdfConstants.ts
@@ -2,10 +2,10 @@ export const MARGIN = 5
 export const LINE_WIDTH = 0.1
 
 export const FONT_SIZE = {
-  TITLE: 9,
-  HEADER: 7,
-  CELL: 7,
-  SMALL: 6,
+  TITLE: 27,
+  HEADER: 21,
+  CELL: 21,
+  SMALL: 18,
 } as const
 
 export function hexToRgb(hex: string): [number, number, number] {

--- a/apps/admin/src/features/competitions/lib/pdfScheduleSheet.ts
+++ b/apps/admin/src/features/competitions/lib/pdfScheduleSheet.ts
@@ -35,9 +35,9 @@ export function renderScheduleSheet(doc: jsPDF, data: CompetitionPdfData): void 
   const refColW = pairWidth * 0.3
 
   // 幅が狭い場合はフォントを縮小
-  let fontSize: number = FONT_SIZE.SMALL // 6
-  if (pairWidth < 30) fontSize = 4.5
-  else if (pairWidth < 40) fontSize = 5
+  let fontSize: number = FONT_SIZE.SMALL // 18
+  if (pairWidth < 30) fontSize = 13.5
+  else if (pairWidth < 40) fontSize = 15
 
   // カラムスタイルを動���に構築
   const colStyles: Record<number, { cellWidth: number; halign: 'center' }> = {


### PR DESCRIPTION
## Summary

- `pdfConstants.ts` のフォントサイズ定数を全て3倍に変更
  - TITLE: 9 → 27
  - HEADER: 7 → 21
  - CELL: 7 → 21
  - SMALL: 6 → 18
- `pdfScheduleSheet.ts` の会場数による動的縮小フォントも3倍に変更
  - 4.5 → 13.5（会場が多く幅が狭い場合）
  - 5 → 15（やや幅が狭い場合）

## Test plan

- [ ] 大会PDFエクスポートを実行し、メンバー表・リーグ表・タイムスケジュール全シートでフォントが以前より大きく表示されることを確認
- [ ] 会場数が多い場合（幅が狭くなるケース）でも文字が適切に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)