### PR TITLE
feat(admin): PDFエクスポートのフォントサイズを2倍に調整

### DIFF
--- a/apps/admin/src/features/competitions/lib/pdfConstants.ts
+++ b/apps/admin/src/features/competitions/lib/pdfConstants.ts
@@ -2,10 +2,10 @@ export const MARGIN = 5
 export const LINE_WIDTH = 0.1
 
 export const FONT_SIZE = {
-  TITLE: 27,
-  HEADER: 21,
-  CELL: 21,
-  SMALL: 18,
+  TITLE: 18,
+  HEADER: 14,
+  CELL: 14,
+  SMALL: 12,
 } as const
 
 export function hexToRgb(hex: string): [number, number, number] {

--- a/apps/admin/src/features/competitions/lib/pdfScheduleSheet.ts
+++ b/apps/admin/src/features/competitions/lib/pdfScheduleSheet.ts
@@ -35,9 +35,9 @@ export function renderScheduleSheet(doc: jsPDF, data: CompetitionPdfData): void 
   const refColW = pairWidth * 0.3
 
   // 幅が狭い場合はフォントを縮小
-  let fontSize: number = FONT_SIZE.SMALL // 18
-  if (pairWidth < 30) fontSize = 13.5
-  else if (pairWidth < 40) fontSize = 15
+  let fontSize: number = FONT_SIZE.SMALL // 12
+  if (pairWidth < 30) fontSize = 9
+  else if (pairWidth < 40) fontSize = 10
 
   // カラムスタイルを動���に構築
   const colStyles: Record<number, { cellWidth: number; halign: 'center' }> = {


### PR DESCRIPTION
## Summary

- フォントサイズを元の3倍から2倍に調整
  - TITLE: 9 → 18
  - HEADER: 7 → 14
  - CELL: 7 → 14
  - SMALL: 6 → 12
- タイムスケジュールの動的縮小フォントも2倍に変更
  - 4.5 → 9
  - 5 → 10

## Test plan

- [ ] 大会PDFエクスポートを実行し、全シートでフォントが適切なサイズで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)