### PR TITLE
feat: タグを用いた競技・試合の表示制御と管理機能の整備

### DIFF
--- a/api/repository/match_sql.go
+++ b/api/repository/match_sql.go
@@ -243,8 +243,10 @@ func (r match) SaveMatchEntriesBatch(ctx context.Context, db *gorm.DB, entries [
 func (r match) ListActiveMatchesByLocationID(ctx context.Context, db *gorm.DB, locationID string) ([]*db_model.Match, error) {
 	var matches []*db_model.Match
 	err := db.WithContext(ctx).
-		Where("location_id = ? AND status IN ?", locationID, []string{"STANDBY", "ONGOING"}).
-		Order("time ASC, id ASC").
+		Joins("JOIN competitions ON matches.competition_id = competitions.id").
+		Joins("JOIN scenes ON competitions.scene_id = scenes.id").
+		Where("matches.location_id = ? AND matches.status IN ? AND scenes.is_deleted = ?", locationID, []string{"STANDBY", "ONGOING"}, false).
+		Order("matches.time ASC, matches.id ASC").
 		Find(&matches).Error
 	if err != nil {
 		return nil, errors.Wrap(err)

--- a/api/service/league.go
+++ b/api/service/league.go
@@ -647,7 +647,7 @@ func computeNewStandings(
 	standings := make([]*model.Standing, len(allStats))
 	for i, s := range allStats {
 		standings[i] = &model.Standing{
-			ID:            competitionID,
+			ID:            competitionID + "_" + s.TeamID,
 			TeamID:        s.TeamID,
 			Win:           int32(s.Win),
 			Draw:          int32(s.Draw),

--- a/apps/admin/src/features/matches/api.ts
+++ b/apps/admin/src/features/matches/api.ts
@@ -19,7 +19,7 @@ export const GET_ADMIN_MATCHES = gql`
       location { id name }
       locationManual
       competition {
-        id name type sport { id name }
+        id name type sport { id name } scene { id name }
       }
       winnerTeam { id }
       entries { id team { id name } score }

--- a/apps/admin/src/features/matches/components/ActiveMatchesPage.tsx
+++ b/apps/admin/src/features/matches/components/ActiveMatchesPage.tsx
@@ -108,10 +108,12 @@ export function ActiveMatchesPage() {
     matches: filteredMatches,
     allMatches: matches,
     sports,
+    sceneOptions,
     sportFilter,
     compTypeFilter,
     bracketFilter,
     statusFilter,
+    sceneFilter,
     bracketOptions,
     handleFilterChange,
     resetFilters,
@@ -183,6 +185,11 @@ export function ActiveMatchesPage() {
   const filterDefs: FilterDef[] = useMemo(() => {
     const defs: FilterDef[] = [
       {
+        key: 'scene',
+        label: 'タグ',
+        options: sceneOptions.map(s => ({ value: s.id, label: s.name })),
+      },
+      {
         key: 'sport',
         label: '競技',
         options: sports.map(s => ({ value: s.id, label: s.name })),
@@ -206,14 +213,15 @@ export function ActiveMatchesPage() {
       options: STATUS_OPTIONS,
     })
     return defs
-  }, [sports, compTypeFilter, bracketOptions])
+  }, [sceneOptions, sports, compTypeFilter, bracketOptions])
 
   const filterValues = useMemo(() => ({
+    scene: sceneFilter,
     sport: sportFilter,
     compType: compTypeFilter,
     bracket: bracketFilter,
     status: statusFilter,
-  }), [sportFilter, compTypeFilter, bracketFilter, statusFilter])
+  }), [sceneFilter, sportFilter, compTypeFilter, bracketFilter, statusFilter])
 
   const handleCardClick = (row: MatchRow) => {
     matchEdit.openMatch(toActiveMatch(row))

--- a/apps/admin/src/features/matches/hooks/useActiveMatches.ts
+++ b/apps/admin/src/features/matches/hooks/useActiveMatches.ts
@@ -14,6 +14,8 @@ export type MatchRow = {
   bracketName: string
   sportId: string
   sportName: string
+  sceneId: string
+  sceneName: string
   locationId: string
   locationName: string
   teamAId: string
@@ -42,12 +44,13 @@ function toStatusLabel(status: string): string {
 
 export function useActiveMatches() {
   const { data, loading, error, refetch } = useGetAdminMatchesQuery({ fetchPolicy: 'cache-and-network' })
-  const { values: fp, set: setFilter, reset: resetFilters } = useFilterParams(['sport', 'compType', 'bracket', 'status'], { status: 'ONGOING' })
+  const { values: fp, set: setFilter, reset: resetFilters } = useFilterParams(['sport', 'compType', 'bracket', 'status', 'scene'], { status: 'ONGOING' })
 
   const sportFilter = fp.sport
   const compTypeFilter = fp.compType
   const bracketFilter = fp.bracket
   const statusFilter = fp.status
+  const sceneFilter = fp.scene
 
   const matches: MatchRow[] = useMemo(() => {
     return (data?.matches ?? []).map(m => {
@@ -65,6 +68,8 @@ export function useActiveMatches() {
         bracketName: '',
         sportId: m.competition.sport.id,
         sportName: m.competition.sport.name,
+        sceneId: m.competition.scene.id,
+        sceneName: m.competition.scene.name,
         locationId: m.location?.id ?? '',
         locationName: m.location?.name ?? '',
         teamAId: entry0?.team?.id ?? '',
@@ -89,6 +94,14 @@ export function useActiveMatches() {
     return Array.from(map, ([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name))
   }, [matches])
 
+  const sceneOptions = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const m of matches) {
+      if (!map.has(m.sceneId)) map.set(m.sceneId, m.sceneName)
+    }
+    return Array.from(map, ([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name))
+  }, [matches])
+
   const bracketOptions = useMemo(() => {
     if (compTypeFilter !== 'TOURNAMENT') return []
     const map = new Map<string, string>()
@@ -104,12 +117,13 @@ export function useActiveMatches() {
 
   const filtered = useMemo(() => {
     let result = matches
+    if (sceneFilter) result = result.filter(m => m.sceneId === sceneFilter)
     if (sportFilter) result = result.filter(m => m.sportId === sportFilter)
     if (compTypeFilter) result = result.filter(m => m.competitionType === compTypeFilter)
     if (bracketFilter) result = result.filter(m => m.bracketType === bracketFilter)
     if (statusFilter) result = result.filter(m => m.status === statusFilter)
     return result
-  }, [matches, sportFilter, compTypeFilter, bracketFilter, statusFilter])
+  }, [matches, sceneFilter, sportFilter, compTypeFilter, bracketFilter, statusFilter])
 
   const handleFilterChange = useCallback((key: string, value: string) => {
     setFilter(key, value)
@@ -122,10 +136,12 @@ export function useActiveMatches() {
     matches: filtered,
     allMatches: matches,
     sports,
+    sceneOptions,
     sportFilter,
     compTypeFilter,
     bracketFilter,
     statusFilter,
+    sceneFilter,
     bracketOptions,
     setFilter,
     handleFilterChange,

--- a/apps/admin/src/features/tags/components/TagDetailPage.tsx
+++ b/apps/admin/src/features/tags/components/TagDetailPage.tsx
@@ -1,5 +1,5 @@
 import { Box, Breadcrumbs, Button, ButtonBase, Card, CardContent, TextField, Typography } from '@mui/material'
-import DeleteIcon from '@mui/icons-material/Delete'
+import BlockOutlinedIcon from '@mui/icons-material/BlockOutlined'
 import CheckIcon from '@mui/icons-material/Check'
 import { BackButton } from '@/components/ui/BackButton'
 import { useState } from 'react'
@@ -40,7 +40,7 @@ export function TagDetailPage({ tagId, onBack }: Props) {
     setDeleteDialogOpen(false)
     try {
       await handleDelete()
-      showToast('タグを削除しました')
+      showToast('タグを無効化しました')
       onBack()
     } catch {
       // エラートーストはhook側で表示済み
@@ -52,7 +52,7 @@ export function TagDetailPage({ tagId, onBack }: Props) {
   const onRestore = async () => {
     try {
       await handleRestore()
-      showToast('タグを復元しました')
+      showToast('タグを有効化しました')
     } catch {
       // エラートーストはhook側で表示済み
     }
@@ -99,16 +99,16 @@ export function TagDetailPage({ tagId, onBack }: Props) {
                     '&:hover': { backgroundColor: '#E8F5E9', borderColor: '#2E7D32' },
                   }}
                 >
-                  このタグを復元
+                  このタグを有効化
                 </Button>
               ) : (
                 <Button
                   variant="outlined"
-                  startIcon={<DeleteIcon sx={{ color: '#D71212' }} />}
+                  startIcon={<BlockOutlinedIcon sx={{ color: '#D71212' }} />}
                   onClick={() => setDeleteDialogOpen(true)}
                   sx={DELETE_BUTTON_SX}
                 >
-                  このタグを削除
+                  このタグを無効化
                 </Button>
               )}
               <Button
@@ -128,8 +128,8 @@ export function TagDetailPage({ tagId, onBack }: Props) {
 
       <ConfirmDialog
         open={deleteDialogOpen}
-        title="タグを削除しますか？"
-        description={`「${tagName}」を削除します。削除後は一覧から無効として表示されます。`}
+        title="タグを無効化しますか？"
+        description={`「${tagName}」を無効化します。無効化後はpanelに表示されなくなります。`}
         onClose={() => setDeleteDialogOpen(false)}
         onConfirm={onConfirmDelete}
       />

--- a/apps/admin/src/gql/__generated__/graphql.ts
+++ b/apps/admin/src/gql/__generated__/graphql.ts
@@ -1814,7 +1814,7 @@ export type GetAdminLocationsForMatchesQuery = { __typename?: 'Query', locations
 export type GetAdminMatchesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAdminMatchesQuery = { __typename?: 'Query', matches: Array<{ __typename?: 'Match', id: string, time: string, timeManual: boolean, status: MatchStatus, locationManual: boolean, location?: { __typename?: 'Location', id: string, name: string } | null, competition: { __typename?: 'Competition', id: string, name: string, type: CompetitionType, sport: { __typename?: 'Sport', id: string, name: string } }, winnerTeam?: { __typename?: 'Team', id: string } | null, entries: Array<{ __typename?: 'MatchEntry', id: string, score: number, team?: { __typename?: 'Team', id: string, name: string } | null }>, judgment?: { __typename?: 'Judgment', id: string, name?: string | null, isAttending: boolean, user?: { __typename?: 'User', id: string } | null, team?: { __typename?: 'Team', id: string } | null, group?: { __typename?: 'Group', id: string } | null } | null }> };
+export type GetAdminMatchesQuery = { __typename?: 'Query', matches: Array<{ __typename?: 'Match', id: string, time: string, timeManual: boolean, status: MatchStatus, locationManual: boolean, location?: { __typename?: 'Location', id: string, name: string } | null, competition: { __typename?: 'Competition', id: string, name: string, type: CompetitionType, sport: { __typename?: 'Sport', id: string, name: string }, scene: { __typename?: 'Scene', id: string, name: string } }, winnerTeam?: { __typename?: 'Team', id: string } | null, entries: Array<{ __typename?: 'MatchEntry', id: string, score: number, team?: { __typename?: 'Team', id: string, name: string } | null }>, judgment?: { __typename?: 'Judgment', id: string, name?: string | null, isAttending: boolean, user?: { __typename?: 'User', id: string } | null, team?: { __typename?: 'Team', id: string } | null, group?: { __typename?: 'Group', id: string } | null } | null }> };
 
 export type GetAdminCompetitionMatchesQueryVariables = Exact<{
   competitionId: Scalars['ID']['input'];
@@ -4575,6 +4575,10 @@ export const GetAdminMatchesDocument = gql`
       name
       type
       sport {
+        id
+        name
+      }
+      scene {
         id
         name
       }

--- a/apps/panel/src/features/games/api.ts
+++ b/apps/panel/src/features/games/api.ts
@@ -13,6 +13,7 @@ export const GET_COMPETITIONS = gql`
       scene {
         id
         name
+        isDeleted
       }
       teams {
         id

--- a/apps/panel/src/features/games/hook/index.ts
+++ b/apps/panel/src/features/games/hook/index.ts
@@ -13,7 +13,7 @@ export const useFetchGames = (_filter: boolean = false) => {
     errorPolicy: 'all',
   });
   return {
-    games: (data?.competitions ?? []).filter(Boolean),
+    games: (data?.competitions ?? []).filter(c => c && !c.scene?.isDeleted),
     isFetching: loading,
     refresh: refetch,
   };

--- a/apps/panel/src/features/matches/api.ts
+++ b/apps/panel/src/features/matches/api.ts
@@ -19,6 +19,7 @@ export const GET_MATCHES = gql`
         }
         scene {
           id
+          isDeleted
         }
       }
       winnerTeam {
@@ -86,6 +87,9 @@ export const GET_JUDGE_MATCH_AT_LOCATION = gql`
         id
         name
         type
+        scene {
+          isDeleted
+        }
       }
       entries {
         id

--- a/apps/panel/src/features/matches/hook/index.ts
+++ b/apps/panel/src/features/matches/hook/index.ts
@@ -8,7 +8,7 @@ export const useFetchMatches = () => {
     errorPolicy: 'all',
   });
   return {
-    matches: (data?.matches ?? []).filter(Boolean),
+    matches: (data?.matches ?? []).filter(m => m && !m.competition?.scene?.isDeleted),
     isFetching: loading,
     refresh: refetch,
   };

--- a/apps/panel/src/features/matches/hook/useJudgeFlow.ts
+++ b/apps/panel/src/features/matches/hook/useJudgeFlow.ts
@@ -44,7 +44,7 @@ export function useJudgeFlow(locationId: string): JudgeFlowResult {
       const { data } = await fetchMatch({ variables: { locationId } });
       const match = data?.nextJudgeMatchAtLocation ?? null;
 
-      if (!match) {
+      if (!match || match.competition?.scene?.isDeleted) {
         setState(hasSubmittedRef.current ? "done" : "no-match");
         retryCountRef.current = 0;
         return;

--- a/apps/panel/src/gql/__generated__/graphql.ts
+++ b/apps/panel/src/gql/__generated__/graphql.ts
@@ -29,7 +29,7 @@ export type ApplyCompetitionDefaultsInput = {
   breakDuration: Scalars['Int']['input'];
   locationId?: InputMaybe<Scalars['ID']['input']>;
   matchDuration: Scalars['Int']['input'];
-  startTime: Scalars['String']['input'];
+  startTime?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** SEEDスロットへのチーム手動配置 */
@@ -102,11 +102,6 @@ export type CreateInformationInput = {
   content: Scalars['String']['input'];
   status?: InputMaybe<Scalars['String']['input']>;
   title: Scalars['String']['input'];
-};
-
-export type CreateJudgmentInput = {
-  entry: JudgmentEntry;
-  id: Scalars['ID']['input'];
 };
 
 export type CreateLeagueInput = {
@@ -343,8 +338,6 @@ export type Mutation = {
   /** 画像アップロード用のURLを発行する */
   createImageUploadURL: ImageUploadUrl;
   createInformation: Information;
-  /** 審判を作成する */
-  createJudgment: Judgment;
   /** リーグを追加する */
   createLeague: League;
   /** 場所を追加する */
@@ -538,11 +531,6 @@ export type MutationCreateImageUploadUrlArgs = {
 
 export type MutationCreateInformationArgs = {
   input: CreateInformationInput;
-};
-
-
-export type MutationCreateJudgmentArgs = {
-  input: CreateJudgmentInput;
 };
 
 
@@ -986,7 +974,7 @@ export type Query = {
   /** 進出先の期待チーム数と現在のエントリー数を取得する */
   promotionStatus: PromotionStatus;
   rule: Rule;
-  rules: Array<Maybe<Rule>>;
+  rules: Array<Rule>;
   scene: Scene;
   scenes: Array<Scene>;
   sport: Sport;
@@ -1430,7 +1418,7 @@ export type GetPanelGroupQuery = { __typename?: 'Query', group: { __typename?: '
 export type GetPanelCompetitionsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetPanelCompetitionsQuery = { __typename?: 'Query', competitions: Array<{ __typename?: 'Competition', id: string, name: string, type: CompetitionType, sport: { __typename?: 'Sport', id: string }, scene: { __typename?: 'Scene', id: string, name: string }, teams: Array<{ __typename?: 'Team', id: string }>, league?: { __typename?: 'League', id: string } | null }> };
+export type GetPanelCompetitionsQuery = { __typename?: 'Query', competitions: Array<{ __typename?: 'Competition', id: string, name: string, type: CompetitionType, sport: { __typename?: 'Sport', id: string }, scene: { __typename?: 'Scene', id: string, name: string, isDeleted: boolean }, teams: Array<{ __typename?: 'Team', id: string }>, league?: { __typename?: 'League', id: string } | null }> };
 
 export type GetPanelLeagueStandingsQueryVariables = Exact<{
   leagueId: Scalars['ID']['input'];
@@ -1485,7 +1473,7 @@ export type GetPanelLocationQuery = { __typename?: 'Query', location: { __typena
 export type GetPanelMatchesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetPanelMatchesQuery = { __typename?: 'Query', matches: Array<{ __typename?: 'Match', id: string, time: string, status: MatchStatus, location?: { __typename?: 'Location', id: string, name: string } | null, competition: { __typename?: 'Competition', id: string, name: string, type: CompetitionType, sport: { __typename?: 'Sport', id: string }, scene: { __typename?: 'Scene', id: string } }, winnerTeam?: { __typename?: 'Team', id: string, name: string } | null, entries: Array<{ __typename?: 'MatchEntry', id: string, score: number, team?: { __typename?: 'Team', id: string, name: string } | null }>, judgment?: { __typename?: 'Judgment', id: string, isAttending: boolean, user?: { __typename?: 'User', id: string } | null, team?: { __typename?: 'Team', id: string, name: string } | null, group?: { __typename?: 'Group', id: string } | null } | null }> };
+export type GetPanelMatchesQuery = { __typename?: 'Query', matches: Array<{ __typename?: 'Match', id: string, time: string, status: MatchStatus, location?: { __typename?: 'Location', id: string, name: string } | null, competition: { __typename?: 'Competition', id: string, name: string, type: CompetitionType, sport: { __typename?: 'Sport', id: string }, scene: { __typename?: 'Scene', id: string, isDeleted: boolean } }, winnerTeam?: { __typename?: 'Team', id: string, name: string } | null, entries: Array<{ __typename?: 'MatchEntry', id: string, score: number, team?: { __typename?: 'Team', id: string, name: string } | null }>, judgment?: { __typename?: 'Judgment', id: string, isAttending: boolean, user?: { __typename?: 'User', id: string } | null, team?: { __typename?: 'Team', id: string, name: string } | null, group?: { __typename?: 'Group', id: string } | null } | null }> };
 
 export type SubmitPanelMatchScoreMutationVariables = Exact<{
   matchId: Scalars['ID']['input'];
@@ -1500,7 +1488,7 @@ export type GetJudgeMatchAtLocationQueryVariables = Exact<{
 }>;
 
 
-export type GetJudgeMatchAtLocationQuery = { __typename?: 'Query', nextJudgeMatchAtLocation?: { __typename?: 'Match', id: string, time: string, status: MatchStatus, location?: { __typename?: 'Location', id: string, name: string } | null, competition: { __typename?: 'Competition', id: string, name: string, type: CompetitionType }, entries: Array<{ __typename?: 'MatchEntry', id: string, score: number, team?: { __typename?: 'Team', id: string, name: string } | null }>, judgment?: { __typename?: 'Judgment', id: string, isAttending: boolean } | null } | null };
+export type GetJudgeMatchAtLocationQuery = { __typename?: 'Query', nextJudgeMatchAtLocation?: { __typename?: 'Match', id: string, time: string, status: MatchStatus, location?: { __typename?: 'Location', id: string, name: string } | null, competition: { __typename?: 'Competition', id: string, name: string, type: CompetitionType, scene: { __typename?: 'Scene', isDeleted: boolean } }, entries: Array<{ __typename?: 'MatchEntry', id: string, score: number, team?: { __typename?: 'Team', id: string, name: string } | null }>, judgment?: { __typename?: 'Judgment', id: string, isAttending: boolean } | null } | null };
 
 export type StartMatchJudgingMutationVariables = Exact<{
   matchId: Scalars['ID']['input'];
@@ -1675,6 +1663,7 @@ export const GetPanelCompetitionsDocument = gql`
     scene {
       id
       name
+      isDeleted
     }
     teams {
       id
@@ -2080,6 +2069,7 @@ export const GetPanelMatchesDocument = gql`
       }
       scene {
         id
+        isDeleted
       }
     }
     winnerTeam {
@@ -2204,6 +2194,9 @@ export const GetJudgeMatchAtLocationDocument = gql`
       id
       name
       type
+      scene {
+        isDeleted
+      }
     }
     entries {
       id


### PR DESCRIPTION
## Summary

- **リーグ順位表バグ修正**: Standing.IDが全チーム同一だったためApolloキャッシュ正規化で1件に上書きされる問題を修正。2位以下の勝ち点率・得点率が表示されない原因だった
- **panelのタグ連動非表示**: 無効化したタグに紐づく競技・試合・審判担当試合をpanelに表示しないよう実装（useFetchGames / useFetchMatches / useJudgeFlow）
- **審判フローのバックエンドフィルタ**: `ListActiveMatchesByLocationID`でsceneをJOINし、無効タグの試合が時刻的に先にある場合でも有効タグの試合へ正しく進めるよう修正
- **タグ管理UIの文言変更**: admin側の「削除/復元」を「無効化/有効化」に統一し、操作の意図を明確化
- **admin試合管理にタグフィルタ追加**: 当日ONにしているタグで試合一覧を絞り込めるよう対応

## Test plan

- [ ] リーグ順位表で全チームの勝ち点率・得点率が表示されることを確認
- [ ] adminでタグを無効化→panelの競技・試合一覧から該当タグのコンテンツが消えることを確認
- [ ] 同一会場に無効タグの試合（先）・有効タグの試合（後）がある状態でQRスキャンし、有効タグの試合に進むことを確認
- [ ] adminタグ管理の「無効化」「有効化」ボタンとダイアログ文言を確認
- [ ] admin試合管理画面のタグフィルタで絞り込みが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)