### PR TITLE
fix(admin): ビルドエラー修正 — deeplink MatchRowにsceneId/sceneNameを追加

### DIFF
--- a/apps/admin/src/features/matches/components/ActiveMatchesPage.tsx
+++ b/apps/admin/src/features/matches/components/ActiveMatchesPage.tsx
@@ -164,6 +164,8 @@ export function ActiveMatchesPage() {
       bracketName: '',
       sportId: m.competition.sport?.id ?? '',
       sportName: m.competition.sport?.name ?? '',
+      sceneId: '',
+      sceneName: '',
       locationId: m.location?.id ?? '',
       locationName: m.location?.name ?? '',
       teamAId: entry0?.team?.id ?? '',


### PR DESCRIPTION
## Summary

- #119 マージ後にビルドエラーが発生していた問題を修正
- `ActiveMatchesPage` のdeeplink経由MatchRow手動構築で `sceneId` / `sceneName` フィールドが欠落していたTS2739エラーを解消
- `GET_ADMIN_MATCH` は scene を含まないため空文字フォールバックで対応

## Test plan

- [ ] `yarn build` がエラーなく完了することを確認
- [ ] deeplinkで試合を開いた際に正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)