### PR TITLE
fix: Scene.enableリゾルバーのpanicを実装に置き換え

### DIFF
--- a/api/graph/generated.go
+++ b/api/graph/generated.go
@@ -581,7 +581,6 @@ type RuleResolver interface {
 	Sport(ctx context.Context, obj *model.Rule) (*model.Sport, error)
 }
 type SceneResolver interface {
-	Enable(ctx context.Context, obj *model.Scene) (bool, error)
 	SportScenes(ctx context.Context, obj *model.Scene) ([]*model.SportScene, error)
 }
 type SportResolver interface {
@@ -20620,7 +20619,7 @@ func (ec *executionContext) _Scene_enable(ctx context.Context, field graphql.Col
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Scene().Enable(rctx, obj)
+		return obj.Enable, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -20641,8 +20640,8 @@ func (ec *executionContext) fieldContext_Scene_enable(_ context.Context, field g
 	fc = &graphql.FieldContext{
 		Object:     "Scene",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
 		},
@@ -30989,41 +30988,10 @@ func (ec *executionContext) _Scene(ctx context.Context, sel ast.SelectionSet, ob
 				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "enable":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Scene_enable(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
+			out.Values[i] = ec._Scene_enable(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
 			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "sportScenes":
 			field := field
 

--- a/api/graph/model.resolvers.go
+++ b/api/graph/model.resolvers.go
@@ -6,7 +6,6 @@ package graph
 
 import (
 	"context"
-	"fmt"
 	"sports-day/api/db_model"
 	"sports-day/api/graph/model"
 	"sports-day/api/loader"
@@ -357,7 +356,7 @@ func (r *ruleResolver) Sport(ctx context.Context, obj *model.Rule) (*model.Sport
 
 // Enable is the resolver for the enable field.
 func (r *sceneResolver) Enable(ctx context.Context, obj *model.Scene) (bool, error) {
-	panic(fmt.Errorf("not implemented: Enable - enable"))
+	return obj.Enable, nil
 }
 
 // SportScenes is the resolver for the sportScenes field.

--- a/api/graph/model.resolvers.go
+++ b/api/graph/model.resolvers.go
@@ -354,11 +354,6 @@ func (r *ruleResolver) Sport(ctx context.Context, obj *model.Rule) (*model.Sport
 	return model.FormatSportResponse(sports[0]), nil
 }
 
-// Enable is the resolver for the enable field.
-func (r *sceneResolver) Enable(ctx context.Context, obj *model.Scene) (bool, error) {
-	return obj.Enable, nil
-}
-
 // SportScenes is the resolver for the sportScenes field.
 func (r *sceneResolver) SportScenes(ctx context.Context, obj *model.Scene) ([]*model.SportScene, error) {
 	res, err := loader.LoadSportScenesByScene(ctx, obj.ID)
@@ -853,3 +848,10 @@ type tournamentResolver struct{ *Resolver }
 type tournamentRankingResolver struct{ *Resolver }
 type tournamentSlotResolver struct{ *Resolver }
 type userResolver struct{ *Resolver }
+
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//    it when you're done.
+//  - You have helper methods in this file. Move them out to keep these resolver files clean.


### PR DESCRIPTION
## Summary

- `make gen-api` 実行時に gqlgen が `Scene.enable` のリゾルバースタブを生成したが、`panic` のまま残っていた
- `scenes` クエリで `enable` フィールドを取得する際に `INTERNAL_SERVER_ERROR` が発生していた
- `return obj.Enable, nil` に置き換えて修正

## 変更内容

`api/graph/model.resolvers.go`
```go
// before
func (r *sceneResolver) Enable(ctx context.Context, obj *model.Scene) (bool, error) {
    panic(fmt.Errorf("not implemented: Enable - enable"))
}

// after
func (r *sceneResolver) Enable(ctx context.Context, obj *model.Scene) (bool, error) {
    return obj.Enable, nil
}
```

## Test plan

- [ ] admin タグ一覧が正常に表示される（`scenes.N.enable` エラーが消える）

🤖 Generated with [Claude Code](https://claude.com/claude-code)