### PR TITLE
fix: コピーライト表記の年を2024から2026に更新

### DIFF
--- a/apps/form/src/components/layouts/PrivacyPolicy.tsx
+++ b/apps/form/src/components/layouts/PrivacyPolicy.tsx
@@ -74,7 +74,7 @@ const PrivacyPolicy = () => {
                         fontWeight={"600"}
                         sx={{ color: (theme) => theme.palette.button.light }}
                     >
-                        (C)2024
+                        (C)2026
                     </Typography>
                     <WiderLogo/>
                 </Stack>

--- a/apps/panel/app/(auth)/login/page.tsx
+++ b/apps/panel/app/(auth)/login/page.tsx
@@ -92,7 +92,7 @@ export default function Page() {
                                         <Button sx={{width: "100%"}}>
                                             <Stack direction={"row"} spacing={0.5}>
                                                 <Typography fontWeight={"600"}
-                                                            color={theme.palette.text.disabled}>(C)2024</Typography>
+                                                            color={theme.palette.text.disabled}>(C)2026</Typography>
                                                 <WiderLogo/>
                                             </Stack>
                                         </Button>

--- a/apps/panel/app/offline/page.tsx
+++ b/apps/panel/app/offline/page.tsx
@@ -45,7 +45,7 @@ export default function Page() {
                         <Typography pb={2} fontSize={"13px"} fontWeight={"400"} color={"#9aa6e5"}>SPORTSDAYを使うにはCookieが必要です</Typography>
                         <Button>
                             <Stack direction={"row"} spacing={0.5}>
-                                <Typography fontWeight={"600"} color={"#99a5d6"}>(C)2024</Typography>
+                                <Typography fontWeight={"600"} color={"#99a5d6"}>(C)2026</Typography>
                                 <WiderLogo/>
                             </Stack>
                         </Button>

--- a/apps/panel/components/layouts/privacyPolicy.tsx
+++ b/apps/panel/components/layouts/privacyPolicy.tsx
@@ -68,7 +68,7 @@ const PrivacyPolicy = () => {
                 <Typography>プライバシーポリシーの変更があった場合、このページに変更を掲載します。</Typography>
                 <Typography>最終更新：2024年10月8日</Typography>
                 <Stack direction={"row"} spacing={0.5}>
-                    <Typography fontWeight={"600"} color={"#99a5d6"}>(C)2024</Typography>
+                    <Typography fontWeight={"600"} color={"#99a5d6"}>(C)2026</Typography>
                     <WiderLogo/>
                 </Stack>
             </Stack>


### PR DESCRIPTION
## Summary
- panel・formアプリ内の `(C)2024 Wider` 表記を `(C)2026` に更新
- 対象箇所: ログインページ、オフラインページ、プライバシーポリシー（panel・form）

## 変更ファイル
- `apps/panel/app/(auth)/login/page.tsx`
- `apps/panel/app/offline/page.tsx`
- `apps/panel/components/layouts/privacyPolicy.tsx`
- `apps/form/src/components/layouts/PrivacyPolicy.tsx`

## Test plan
- [ ] panel ログインページのコピーライト表記が `(C)2026` になっていることを確認
- [ ] panel オフラインページのコピーライト表記が `(C)2026` になっていることを確認
- [ ] panel プライバシーポリシーのコピーライト表記が `(C)2026` になっていることを確認
- [ ] form プライバシーポリシーのコピーライト表記が `(C)2026` になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)