### PR TITLE
feat(ci): panelのDockerビルドにVITE_FORM_URLを追加

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -127,6 +127,7 @@ jobs:
             VITE_OIDC_DISPLAY_NAME=${{ secrets.VITE_OIDC_DISPLAY_NAME }}
             VITE_GA_ID=${{ secrets.VITE_GA_ID }}
             VITE_GRAPHQL_ENDPOINT=${{ secrets.VITE_GRAPHQL_ENDPOINT }}
+            VITE_FORM_URL=${{ secrets.VITE_FORM_URL }}
 
   build-form:
     name: Build Form


### PR DESCRIPTION
## Summary
- `build-and-push.yml` の `build-panel` ジョブに `VITE_FORM_URL` を `build-args` として追加
- これがないとGitHub SecretsにURLを設定してもビルド時に渡されずボタンがdisabledのままになる

## Test plan
- [ ] マージ後のビルドでjoinページの「フォームに答える」ボタンが有効になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)