### PR TITLE
fix: スコア0同士の更新エラー修正と試合状態の自動完了設定

### DIFF
--- a/api/repository/match_sql.go
+++ b/api/repository/match_sql.go
@@ -119,9 +119,6 @@ func (r match) UpdateMatchEntryScore(ctx context.Context, db *gorm.DB, matchId s
 	if result.Error != nil {
 		return nil, errors.Wrap(result.Error)
 	}
-	if result.RowsAffected == 0 {
-		return nil, errors.ErrMatchNotFound
-	}
 
 	var updated db_model.MatchEntry
 	if err := db.WithContext(ctx).Where("match_id = ? AND team_id = ?", matchId, teamId).First(&updated).Error; err != nil {

--- a/apps/admin/src/features/matches/hooks/useMatchEdit.ts
+++ b/apps/admin/src/features/matches/hooks/useMatchEdit.ts
@@ -22,6 +22,12 @@ function computeWinner(a: string, b: string): WinnerType {
   return 'draw'
 }
 
+function bothScoresValid(a: string, b: string): boolean {
+  const numA = parseInt(a, 10)
+  const numB = parseInt(b, 10)
+  return a !== '' && b !== '' && Number.isFinite(numA) && Number.isFinite(numB) && numA >= 0 && numB >= 0
+}
+
 export function useMatchEdit() {
   const [selectedMatch, setSelectedMatch] = useState<ActiveMatch | null>(null)
   const [scoreA, setScoreA] = useState<string>('0')
@@ -35,11 +41,13 @@ export function useMatchEdit() {
   const handleSetScoreA = (v: string) => {
     setScoreA(v)
     setWinner(computeWinner(v, scoreB))
+    if (bothScoresValid(v, scoreB)) setMatchStatus('finished')
   }
 
   const handleSetScoreB = (v: string) => {
     setScoreB(v)
     setWinner(computeWinner(scoreA, v))
+    if (bothScoresValid(scoreA, v)) setMatchStatus('finished')
   }
 
   // 初期値を保持して dirty 検知に使う


### PR DESCRIPTION
## Summary

- **バグ修正**: `UpdateMatchEntryScore` でスコアが既に0の試合に0を再設定すると `RowsAffected=0` となり `MATCH_ENTRY_SCORE_UPDATE_FAILED` が返っていた問題を修正
  - 原因: MySQLは同一値のUPDATEに対して affected rows を0で返す
  - 修正: `RowsAffected == 0` チェックを削除（レコード不存在は直後の `First()` で検知）
  - 効果: 0-0スコア + 勝者指定（不戦勝）が正常に保存できるようになる

- **機能追加**: 試合編集画面でスコアを両方入力した瞬間、試合状態が自動で「完了」に切り替わるように変更
  - 手動でステータスを変更する手間を省略

## Test plan

- [ ] リーグ試合で 0-0 + 勝者を指定して保存できることを確認
- [ ] スコアを入力すると試合状態が「完了」に自動切り替わることを確認
- [ ] 通常スコア（例: 3-1）でも保存が正常に動作することを確認
- [ ] トーナメント試合でスコア差あり + 勝者が自動設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)