### PR TITLE
fix: スポーツエントリー表示のApolloキャッシュ汚染バグを修正

### DIFF
--- a/apps/admin/src/features/competitions/api.ts
+++ b/apps/admin/src/features/competitions/api.ts
@@ -184,6 +184,7 @@ export const GET_ADMIN_SPORT_SCENE_ENTRIES = gql`
     scene(id: $sceneId) {
       id
       sportScenes {
+        id
         sport { id }
         entries {
           id

--- a/apps/admin/src/features/teams/hooks/useTeamDetail.ts
+++ b/apps/admin/src/features/teams/hooks/useTeamDetail.ts
@@ -26,7 +26,7 @@ export function useTeamDetail(teamId: string) {
   const { data: usersData } = useGetAdminUsersQuery({ fetchPolicy: 'cache-and-network' })
   const { data: groupsData } = useGetAdminGroupsQuery({ fetchPolicy: 'cache-and-network' })
   const { data: sportScenesData, loading: sportScenesLoading } = useGetAdminSportScenesForTeamQuery({
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'no-cache',
   })
 
   const team = data?.team

--- a/apps/admin/src/gql/__generated__/graphql.ts
+++ b/apps/admin/src/gql/__generated__/graphql.ts
@@ -1548,7 +1548,7 @@ export type GetAdminSportSceneEntriesQueryVariables = Exact<{
 }>;
 
 
-export type GetAdminSportSceneEntriesQuery = { __typename?: 'Query', scene: { __typename?: 'Scene', id: string, sportScenes: Array<{ __typename?: 'SportScene', sport: { __typename?: 'Sport', id: string }, entries: Array<{ __typename?: 'SportEntry', id: string, team: { __typename?: 'Team', id: string } }> }> } };
+export type GetAdminSportSceneEntriesQuery = { __typename?: 'Query', scene: { __typename?: 'Scene', id: string, sportScenes: Array<{ __typename?: 'SportScene', id: string, sport: { __typename?: 'Sport', id: string }, entries: Array<{ __typename?: 'SportEntry', id: string, team: { __typename?: 'Team', id: string } }> }> } };
 
 export type CreateAdminCompetitionMutationVariables = Exact<{
   input: CreateCompetitionInput;
@@ -3127,6 +3127,7 @@ export const GetAdminSportSceneEntriesDocument = gql`
   scene(id: $sceneId) {
     id
     sportScenes {
+      id
       sport {
         id
       }


### PR DESCRIPTION
## Summary

- `useGetAdminSportScenesForTeamQuery` の `fetchPolicy` を `network-only` から `no-cache` に変更
- `GetAdminSportSceneEntries` クエリの `sportScenes` に `id` フィールドを追加（Apollo正規化の修正）

## 問題の原因

`network-only` はネットワークから取得しつつキャッシュにも書き込み、キャッシュ変更を購読する。
そのため、別のクエリ（`GetAdminSportSceneEntries` 等）がキャッシュを更新すると、
スポーツエントリーのデータが空に上書きされ、チェックボックスが全て未選択状態で表示されていた。

`no-cache` に変更することで：
- キャッシュを読まない・書かない・購読しない
- 他クエリのキャッシュ操作に影響されず、常に正確なデータを表示できる

## Test plan

- [ ] チームの詳細画面を開き、スポーツエントリーが正しく選択状態で表示されることを確認
- [ ] 複数のチームを連続して開いたときに、各チームのエントリー状態が正しく表示されることを確認
- [ ] エントリーの追加・削除後に画面が正しく更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)